### PR TITLE
Let mushrooms grow on podzol

### DIFF
--- a/src/main/resources/data/botanypots/recipes/soil/podzol.json
+++ b/src/main/resources/data/botanypots/recipes/soil/podzol.json
@@ -6,6 +6,6 @@
   "display": {
     "block": "minecraft:podzol"
   },
-  "categories": ["dirt", "grass", "podzol"],
+  "categories": ["dirt", "grass", "podzol", "mushroom"],
   "growthModifier": 0.05
 }


### PR DESCRIPTION
This PR adds the possibility to let all mushrooms also grow on podzol, because they should do it.