### PR TITLE
Support glowshroom of quark 

### DIFF
--- a/src/main/resources/data/quark/recipes/crops/glowshroom.json
+++ b/src/main/resources/data/quark/recipes/crops/glowshroom.json
@@ -1,0 +1,35 @@
+{
+  "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "quark"
+    }
+  ],
+  "seed": {
+    "item": "quark:glowshroom"
+  },
+  "categories":["glowcelium"],
+  "growthTicks": 1600,
+  "display": {
+    "block": "quark:glowshroom"
+  },
+  "results": [
+    {
+      "chance": 0.75,
+      "output": {
+        "item": "quark:glowshroom"
+      },
+      "minRolls": 1,
+      "maxRolls": 1
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "quark:glowshroom"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    }
+  ]
+}

--- a/src/main/resources/data/quark/recipes/soil/glowcelium.json
+++ b/src/main/resources/data/quark/recipes/soil/glowcelium.json
@@ -1,0 +1,11 @@
+{
+  "type": "botanypots:soil",
+  "input": {
+    "item": "quark:glowcelium"
+  },
+  "display": {
+    "block": "quark:glowcelium"
+  },
+  "categories": ["glowcelium"],
+  "growthModifier": 0.05
+}


### PR DESCRIPTION
This PR adds the support of the glowshroom of the mod Quark. It only grows on glowcelium of this mod.