### PR TITLE
fixed mystical agriculture support

### DIFF
--- a/src/main/resources/data/mysticalagriculture/recipes/crops/air.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/air.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:air"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:air_seeds"
   },
-  "categories":["dirt"],
+  "categories": [
+    "dirt"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:air_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:air_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/aluminum.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/aluminum.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:aluminum_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:aluminum_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:aluminum_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/blaze.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/blaze.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:blaze"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:blaze_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:blaze_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:blaze_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/brass.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/brass.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:brass_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:brass_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:brass_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/bronze.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/bronze.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:bronze_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:bronze_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:bronze_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/chrome.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/chrome.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:chrome_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:chrome_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:chrome_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/coal.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/coal.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:coal"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:coal_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:coal_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:coal_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/constantan.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/constantan.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:constantan_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:constantan_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:constantan_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/copper.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/copper.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:copper_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:copper_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:copper_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/coral.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/coral.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:coral"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:coral_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2000,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:coral_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:coral_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/cow.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/cow.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:cow"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:cow_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2500,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:cow_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:cow_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/creeper.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/creeper.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:creeper"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:creeper_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:creeper_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:creeper_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/diamond.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/diamond.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:diamond"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:diamond_seeds"
   },
-  "categories":["supremium"],
+  "categories": [
+    "supremium"
+  ],
   "growthTicks": 4500,
   "display": {
     "block": "mysticalagriculture:diamond_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:diamond_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/dirt.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/dirt.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:dirt"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:dirt_seeds"
   },
-  "categories":["dirt"],
+  "categories": [
+    "inferium"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:dirt_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:dirt_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/dye.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/dye.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:dye"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:dye_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2000,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:dye_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:dye_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/earth.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/earth.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:earth"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:earth_seeds"
   },
-  "categories":["dirt"],
+  "categories": [
+    "dirt"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:earth_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:earth_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/electrum.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/electrum.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:electrum_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:electrum_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:electrum_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/elementium.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/elementium.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:elementium"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:elementium_seeds"
   },
   "categories": [
-    "prudentium"
+    "imperium"
   ],
-  "growthTicks": 2400,
+  "growthTicks": 4000,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:elementium_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:elementium_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:elementium_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/emerald.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/emerald.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:emerald"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:emerald_seeds"
   },
-  "categories":["supremium"],
+  "categories": [
+    "supremium"
+  ],
   "growthTicks": 4500,
   "display": {
     "block": "mysticalagriculture:emerald_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:emerald_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/end.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/end.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:end"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:end_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:end_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:end_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/ender_biotite.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/ender_biotite.json
@@ -7,16 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:glowing_dust"
+      "crop": "mysticalagriculture:ender_biotite"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:glowing_dust_seeds"
+    "item": "mysticalagriculture:ender_biotite_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
-    "block": "mysticalagriculture:glowing_dust_crop",
+    "block": "mysticalagriculture:ender_biotite_crop",
     "properties": {
       "age": 7
     }
@@ -25,20 +27,20 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:glowing_dust_essence"
+        "item": "mysticalagriculture:ender_biotite_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:glowing_dust_seeds"
+        "item": "mysticalagriculture:ender_biotite_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/enderman.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/enderman.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:enderman"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:enderman_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:enderman_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:enderman_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/experience.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/experience.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:experience"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:experience_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:experience_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:experience_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/fire.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/fire.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:fire"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:fire_seeds"
   },
-  "categories":["dirt"],
+  "categories": [
+    "dirt"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:fire_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:fire_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/fish.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/fish.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:fish"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:fish_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2500,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:fish_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:fish_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/ghast.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/ghast.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:ghast"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:ghast_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:ghast_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:ghast_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/glowstone.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/glowstone.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:glowstone"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:glowstone_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:glowstone_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:glowstone_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/gold.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/gold.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:gold"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:gold_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:gold_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:gold_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/graphite.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/graphite.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:graphite_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:graphite_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:graphite_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/honey.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/honey.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:honey"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:honey_seeds"
   },
   "categories": [
     "prudentium"
   ],
   "growthTicks": 2400,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:honey_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:honey_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:honey_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/ice.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/ice.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:ice"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:ice_seeds"
   },
-  "categories":["inferium"],
+  "categories": [
+    "inferium"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:ice_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:ice_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/inferium.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/inferium.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:inferium"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:inferium_seeds"
   },
-  "categories":["inferium"],
+  "categories": [
+    "inferium"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:inferium_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:inferium_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/invar.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/invar.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:invar_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:invar_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:invar_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/iridium.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/iridium.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:iridium_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:iridium_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:iridium_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/iron.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/iron.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:iron"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:iron_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:iron_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:iron_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/lapis_lazuli.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/lapis_lazuli.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:lapis_lazuli"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:lapis_lazuli_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:lapis_lazuli_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:lapis_lazuli_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/lead.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/lead.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:lead_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:lead_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:lead_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/manasteel.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/manasteel.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:manasteel"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:manasteel_seeds"
   },
   "categories": [
-    "prudentium"
+    "tertium"
   ],
-  "growthTicks": 2400,
+  "growthTicks": 3600,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:manasteel_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:manasteel_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:manasteel_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/mithril.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/mithril.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:mithril_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:mithril_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:mithril_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/mystical_flower.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/mystical_flower.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:mystical_flower"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:mystical_flower_seeds"
   },
   "categories": [
     "prudentium"
   ],
   "growthTicks": 2400,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:mystical_flower_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:mystical_flower_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:mystical_flower_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/nature.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/nature.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:nature"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:nature_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2000,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:nature_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:nature_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/nether.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/nether.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:nether"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:nether_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2000,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:nether_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:nether_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/nether_quartz.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/nether_quartz.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:nether_quartz"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:nether_quartz_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:nether_quartz_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:nether_quartz_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/nickel.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/nickel.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:nickel_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:nickel_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:nickel_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/obsidian.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/obsidian.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:obsidian"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:obsidian_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:obsidian_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:obsidian_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/osmium.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/osmium.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:osmium"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:osmium_seeds"
   },
   "categories": [
-    "prudentium"
+    "imperium"
   ],
-  "growthTicks": 2400,
+  "growthTicks": 4000,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:osmium_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:osmium_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:osmium_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/pig.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/pig.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:pig"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:pig_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2500,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:pig_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:pig_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/platinum.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/platinum.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:platinum_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:platinum_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:platinum_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/prismarine.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/prismarine.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:prismarine"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:prismarine_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:prismarine_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:prismarine_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/quartz_enriched_iron.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/quartz_enriched_iron.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:quartz_enriched_iron"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:quartz_enriched_iron_seeds"
   },
   "categories": [
-    "prudentium"
+    "tertium"
   ],
-  "growthTicks": 2400,
+  "growthTicks": 3600,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:quartz_enriched_iron_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:quartz_enriched_iron_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:quartz_enriched_iron_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/rabbit.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/rabbit.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:rabbit"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:rabbit_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:rabbit_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:rabbit_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/redstone.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/redstone.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:redstone"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:redstone_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:redstone_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:redstone_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/refined_glowstone.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/refined_glowstone.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:refined_glowstone"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:refined_glowstone_seeds"
   },
   "categories": [
-    "prudentium"
+    "imperium"
   ],
-  "growthTicks": 2400,
+  "growthTicks": 4000,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:refined_glowstone_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:refined_glowstone_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:refined_glowstone_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/refined_obsidian.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/refined_obsidian.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:refined_obsidian"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:refined_obsidian_seeds"
   },
   "categories": [
-    "prudentium"
+    "imperium"
   ],
-  "growthTicks": 2400,
+  "growthTicks": 4000,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:refined_obsidian_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:refined_obsidian_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:refined_obsidian_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/rubber.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/rubber.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:rubber_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:rubber_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:rubber_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/saltpeter.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/saltpeter.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:saltpeter_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:saltpeter_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:saltpeter_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/sheep.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/sheep.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:sheep"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:sheep_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2500,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:sheep_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:sheep_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/silicon.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/silicon.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:silicon_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:silicon_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:silicon_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/silver.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/silver.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:silver_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:silver_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:silver_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/skeleton.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/skeleton.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:skeleton"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:skeleton_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:skeleton_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:skeleton_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/slime.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/slime.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:slime"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:slime_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2500,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:slime_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:slime_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/spider.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/spider.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:spider"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:spider_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:spider_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:spider_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/squid.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/squid.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:squid"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:squid_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2500,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:squid_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:squid_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/steel.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/steel.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:steel_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:steel_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:steel_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/stone.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/stone.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:stone"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:stone_seeds"
   },
-  "categories":["inferium"],
+  "categories": [
+    "inferium"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:stone_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:stone_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/sulfur.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/sulfur.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:sulfur_seeds"
   },
-  "categories":["prudentium"],
+  "categories": [
+    "prudentium"
+  ],
   "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:sulfur_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:sulfur_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/terrasteel.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/terrasteel.json
@@ -4,15 +4,21 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:terrasteel"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:wither_skeleton_seeds"
+    "item": "mysticalagriculture:terrasteel_seeds"
   },
-  "categories":["supremium"],
+  "categories": [
+    "supremium"
+  ],
   "growthTicks": 4500,
   "display": {
-    "block": "mysticalagriculture:wither_skeleton_crop",
+    "block": "mysticalagriculture:terrasteel_crop",
     "properties": {
       "age": 7
     }
@@ -21,20 +27,20 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:wither_skeleton_essence"
+        "item": "mysticalagriculture:terrasteel_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:wither_skeleton_seeds"
+        "item": "mysticalagriculture:terrasteel_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/tin.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/tin.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:tin_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:tin_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:tin_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/titanium.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/titanium.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:titanium_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:titanium_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:titanium_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/tungsten.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/tungsten.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:tungsten_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:tungsten_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:tungsten_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/turtle.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/turtle.json
@@ -4,13 +4,19 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:turtle"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:turtle_seeds"
   },
-  "categories":["prudentium"],
-  "growthTicks": 2500,
+  "categories": [
+    "prudentium"
+  ],
+  "growthTicks": 2400,
   "display": {
     "block": "mysticalagriculture:turtle_crop",
     "properties": {
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:turtle_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/uranium.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/uranium.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:uranium_seeds"
   },
-  "categories":["imperium"],
+  "categories": [
+    "imperium"
+  ],
   "growthTicks": 4000,
   "display": {
     "block": "mysticalagriculture:uranium_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:uranium_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/water.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/water.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:water"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:water_seeds"
   },
-  "categories":["dirt"],
+  "categories": [
+    "dirt"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:water_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:water_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/wither_skeleton.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/wither_skeleton.json
@@ -7,18 +7,18 @@
     },
     {
       "type": "mysticalagriculture:crop_enabled",
-      "crop": "mysticalagriculture:chicken"
+      "crop": "mysticalagriculture:wither_skeleton"
     }
   ],
   "seed": {
-    "item": "mysticalagriculture:chicken_seeds"
+    "item": "mysticalagriculture:wither_skeleton_seeds"
   },
   "categories": [
-    "prudentium"
+    "supremium"
   ],
-  "growthTicks": 2400,
+  "growthTicks": 4500,
   "display": {
-    "block": "mysticalagriculture:chicken_crop",
+    "block": "mysticalagriculture:wither_skeleton_crop",
     "properties": {
       "age": 7
     }
@@ -27,7 +27,7 @@
     {
       "chance": 0.75,
       "output": {
-        "item": "mysticalagriculture:chicken_essence"
+        "item": "mysticalagriculture:wither_skeleton_essence"
       },
       "minRolls": 1,
       "maxRolls": 1
@@ -35,7 +35,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "mysticalagriculture:chicken_seeds"
+        "item": "mysticalagriculture:wither_skeleton_seeds"
       },
       "minRolls": 1,
       "maxRolls": 1

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/wood.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/wood.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:wood"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:wood_seeds"
   },
-  "categories":["inferium"],
+  "categories": [
+    "inferium"
+  ],
   "growthTicks": 1200,
   "display": {
     "block": "mysticalagriculture:wood_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:wood_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/zinc.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/zinc.json
@@ -13,7 +13,9 @@
   "seed": {
     "item": "mysticalagriculture:zinc_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:zinc_crop",
@@ -30,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:zinc_seeds"
@@ -38,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"

--- a/src/main/resources/data/mysticalagriculture/recipes/crops/zombie.json
+++ b/src/main/resources/data/mysticalagriculture/recipes/crops/zombie.json
@@ -4,12 +4,18 @@
     {
       "type": "forge:mod_loaded",
       "modid": "mysticalagriculture"
+    },
+    {
+      "type": "mysticalagriculture:crop_enabled",
+      "crop": "mysticalagriculture:zombie"
     }
   ],
   "seed": {
     "item": "mysticalagriculture:zombie_seeds"
   },
-  "categories":["tertium"],
+  "categories": [
+    "tertium"
+  ],
   "growthTicks": 3600,
   "display": {
     "block": "mysticalagriculture:zombie_crop",
@@ -26,7 +32,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.05,
       "output": {
         "item": "mysticalagriculture:zombie_seeds"
@@ -34,7 +40,7 @@
       "minRolls": 1,
       "maxRolls": 1
     },
-	{
+    {
       "chance": 0.01,
       "output": {
         "item": "mysticalagriculture:fertilized_essence"


### PR DESCRIPTION
close #41 
Each seed added by mystical agriculture is added now. Also fixed growthTicks being different within same tier.
Deleted jsons which aren't in MA.
Added missing ones.