### PR TITLE
add mushroom category to crimson & warped nylium

### DIFF
--- a/src/main/resources/data/botanypots/recipes/soil/crimson_nylium.json
+++ b/src/main/resources/data/botanypots/recipes/soil/crimson_nylium.json
@@ -6,6 +6,6 @@
   "display": {
     "block": "minecraft:crimson_nylium"
   },
-  "categories": ["dirt", "crimson_nylium", "nylium"],
+  "categories": ["dirt", "crimson_nylium", "nylium", "mushroom"],
   "growthModifier": 0.05
 }

--- a/src/main/resources/data/botanypots/recipes/soil/warped_nylium.json
+++ b/src/main/resources/data/botanypots/recipes/soil/warped_nylium.json
@@ -6,6 +6,6 @@
   "display": {
     "block": "minecraft:warped_nylium"
   },
-  "categories": ["dirt", "warped_nylium", "nylium"],
+  "categories": ["dirt", "warped_nylium", "nylium", "mushroom"],
   "growthModifier": 0.05
 }


### PR DESCRIPTION
Since Minecraft 1.16.2 the new tag "minecraft:mushroom_grow_block" was included. It contains Mycelium & Podzol AND Crimson & Warped Nylium. It is checked at the grow method of red and brown mushrooms. So, red and brown mushrooms can also grow on these two blocks.

I added the mushroom category to the nylium soils, because other mushrooms should also grow there.

Another possibility could be adding the nylium category to the red and brown mushrooms. But I think the invited tag justify the mushroom category for the nylium blocks.