### PR TITLE
Use partial render ticks for smoother rendering

### DIFF
--- a/src/main/java/net/darkhax/botanypots/block/tileentity/RendererBotanyPot.java
+++ b/src/main/java/net/darkhax/botanypots/block/tileentity/RendererBotanyPot.java
@@ -94,7 +94,7 @@ public class RendererBotanyPot extends TileEntityRenderer<TileEntityBotanyPot> {
             
             if (BotanyPots.CLIENT_CONFIG.shouldDoGrowthAnimation()) {
                 
-                final float progressScale = 0.25f + (float) tile.getCurrentGrowthTicks() / tile.getTotalGrowthTicks() * 0.75f;
+                final float progressScale = 0.25f + (tile.getCurrentGrowthTicks() + partial) / tile.getTotalGrowthTicks() * 0.75f;
                 final float growth = MathHelper.clamp(progressScale * 0.625f, 0, 1f);
                 matrix.scale(growth, growth, growth);
             }


### PR DESCRIPTION
Left pot doesn't use partial ticks, right pot does

![botany pots](https://user-images.githubusercontent.com/5553605/94805849-5437af00-03ed-11eb-9ee4-01ee7b6fe77c.gif)
