### PR TITLE
Fix: minor issues with crop defs and recipe classes

### DIFF
--- a/src/main/java/net/darkhax/botanypots/crop/CropInfo.java
+++ b/src/main/java/net/darkhax/botanypots/crop/CropInfo.java
@@ -163,6 +163,12 @@ public class CropInfo extends RecipeDataBase {
         
         this.displayBlocks = displayBlocks;
     }
+
+    @Override
+    public boolean isDynamic() {
+
+        return true;
+    }
     
     @Override
     public IRecipeSerializer<?> getSerializer () {

--- a/src/main/java/net/darkhax/botanypots/fertilizer/FertilizerInfo.java
+++ b/src/main/java/net/darkhax/botanypots/fertilizer/FertilizerInfo.java
@@ -93,6 +93,12 @@ public class FertilizerInfo extends RecipeDataBase {
         
         this.maxTicks = maxTicks;
     }
+
+    @Override
+    public boolean isDynamic() {
+
+        return true;
+    }
     
     @Override
     public IRecipeSerializer<?> getSerializer () {

--- a/src/main/java/net/darkhax/botanypots/soil/SoilInfo.java
+++ b/src/main/java/net/darkhax/botanypots/soil/SoilInfo.java
@@ -133,7 +133,13 @@ public class SoilInfo extends RecipeDataBase {
         
         return this.getLightLevel().orElseGet( () -> this.renderState.getState().getLightValue(world, pos));
     }
-    
+
+    @Override
+    public boolean isDynamic() {
+
+        return true;
+    }
+
     @Override
     public IRecipeSerializer<?> getSerializer () {
         

--- a/src/main/resources/data/byg/recipes/crops/blue_glowcane.json
+++ b/src/main/resources/data/byg/recipes/crops/blue_glowcane.json
@@ -1,5 +1,15 @@
 {
   "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "byg:blue_glowcane"
+    }
+  ],
   "seed": {
     "item": "byg:blue_glowcane"
   },

--- a/src/main/resources/data/byg/recipes/crops/blueberries.json
+++ b/src/main/resources/data/byg/recipes/crops/blueberries.json
@@ -1,5 +1,15 @@
 {
   "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "byg:blueberries"
+    }
+  ],
   "seed": {
     "item": "byg:blueberries"
   },

--- a/src/main/resources/data/byg/recipes/crops/pink_glowcane.json
+++ b/src/main/resources/data/byg/recipes/crops/pink_glowcane.json
@@ -1,5 +1,15 @@
 {
   "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "byg:pink_glowcane"
+    }
+  ],
   "seed": {
     "item": "byg:pink_glowcane"
   },

--- a/src/main/resources/data/byg/recipes/crops/purple_glowcane.json
+++ b/src/main/resources/data/byg/recipes/crops/purple_glowcane.json
@@ -1,5 +1,15 @@
 {
   "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "byg:purple_glowcane"
+    }
+  ],
   "seed": {
     "item": "byg:purple_glowcane"
   },

--- a/src/main/resources/data/byg/recipes/crops/red_glowcane.json
+++ b/src/main/resources/data/byg/recipes/crops/red_glowcane.json
@@ -1,5 +1,15 @@
 {
   "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "byg:red_glowcane"
+    }
+  ],
   "seed": {
     "item": "byg:red_glowcane"
   },

--- a/src/main/resources/data/byg/recipes/crops/warped_cactus.json
+++ b/src/main/resources/data/byg/recipes/crops/warped_cactus.json
@@ -1,5 +1,15 @@
 {
   "type": "botanypots:crop",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "byg"
+    },
+    {
+      "type": "forge:item_exists",
+      "item": "byg:warped_cactus"
+    }
+  ],
   "seed": {
     "item": "byg:warped_cactus"
   },


### PR DESCRIPTION
Fixes warning and errors in console.

- missing conditions for some byg crops
- mark pseudo recipes (which are just used to load the data) as dynamic, so Minecraft does not try to show them in the recipe book