### PR TITLE
Add Phyto-Gro from Thermal Series as a fertilizer

### DIFF
--- a/src/main/resources/data/thermal/recipes/fertilizers/phytogro.json
+++ b/src/main/resources/data/thermal/recipes/fertilizers/phytogro.json
@@ -1,0 +1,8 @@
+{
+    "type": "botanypots:fertilizer",
+    "fertilizer": {
+        "item": "thermal:phytogro"
+    },
+    "minTicks": 240,
+    "maxTicks": 340
+}

--- a/src/main/resources/data/thermal/recipes/fertilizers/phytogro.json
+++ b/src/main/resources/data/thermal/recipes/fertilizers/phytogro.json
@@ -1,5 +1,15 @@
 {
     "type": "botanypots:fertilizer",
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "thermal"
+        },
+        {
+            "type": "forge:item_exists",
+            "item": "thermal:phytogro"
+        }
+    ],
     "fertilizer": {
         "item": "thermal:phytogro"
     },


### PR DESCRIPTION
Based on its usage as a catalyst, it should be twice as potent as a regular bone meal. Feel free to change the numbers, though.