### PR TITLE
Fix CraftTweakerIntegration for CraftTweaker version 7.1.0 following

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ forge_version=1.16.4-35.0.17
 mcp_version=20201028-1.16.3
 bookshelf_version=9.0.7
 jei_version=7.3.2.25
-crafttweaker_version=7.0.0.51
+crafttweaker_version=7.1.0.72
 hwyla_version=1.10.11-B78_1.16.2
 top_version=1.16-3.0.4-beta-7
 

--- a/src/main/java/net/darkhax/botanypots/BotanyPotHelper.java
+++ b/src/main/java/net/darkhax/botanypots/BotanyPotHelper.java
@@ -32,7 +32,6 @@ public class BotanyPotHelper {
         return manager != null ? manager : SidedExecutor.callForSide( () -> () -> Minecraft.getInstance().player.connection.getRecipeManager(), () -> () -> ServerLifecycleHooks.getCurrentServer().getRecipeManager());
     }
     
-    @Nullable
     public static Map<ResourceLocation, SoilInfo> getSoilData (RecipeManager manager) {
         
         if (manager != null) {
@@ -43,7 +42,6 @@ public class BotanyPotHelper {
         return Collections.emptyMap();
     }
     
-    @Nullable
     public static Map<ResourceLocation, CropInfo> getCropData (RecipeManager manager) {
         
         if (manager != null) {
@@ -53,8 +51,7 @@ public class BotanyPotHelper {
         
         return Collections.emptyMap();
     }
-    
-    @Nullable
+
     public static Map<ResourceLocation, FertilizerInfo> getFertilizerData (RecipeManager manager) {
         
         if (manager != null) {

--- a/src/main/java/net/darkhax/botanypots/BotanyPots.java
+++ b/src/main/java/net/darkhax/botanypots/BotanyPots.java
@@ -1,23 +1,25 @@
 package net.darkhax.botanypots;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import net.darkhax.bookshelf.item.ItemGroupBase;
 import net.darkhax.bookshelf.network.NetworkHelper;
 import net.darkhax.bookshelf.registry.RegistryHelper;
 import net.darkhax.bookshelf.util.ModUtils;
+import net.darkhax.botanypots.addons.crt.CraftTweakerEventSubscription;
 import net.darkhax.botanypots.addons.top.TOPPlugin;
 import net.darkhax.botanypots.network.BreakEffectsMessage;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.InterModComms;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig.Type;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @Mod(BotanyPots.MOD_ID)
 public class BotanyPots {
@@ -45,6 +47,15 @@ public class BotanyPots {
         
         this.registry.initialize(FMLJavaModLoadingContext.get().getModEventBus());
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
+
+        registerModSupport();
+    }
+
+    private void registerModSupport () {
+
+        if (ModList.get().isLoaded("crafttweaker")) {
+            MinecraftForge.EVENT_BUS.register(CraftTweakerEventSubscription.class);
+        }
     }
     
     private void setup (FMLCommonSetupEvent event) {

--- a/src/main/java/net/darkhax/botanypots/addons/crt/BotanyDump.java
+++ b/src/main/java/net/darkhax/botanypots/addons/crt/BotanyDump.java
@@ -1,0 +1,74 @@
+package net.darkhax.botanypots.addons.crt;
+
+import com.blamejared.crafttweaker.CraftTweaker;
+import com.blamejared.crafttweaker.api.CraftTweakerAPI;
+import com.blamejared.crafttweaker.impl.commands.CTCommandCollectionEvent;
+import com.blamejared.crafttweaker.impl.commands.CTCommands;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.RecipeManager;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.util.text.TextFormatting;
+
+import java.util.Map;
+import java.util.Set;
+
+public class BotanyDump implements CTCommands.CommandCallerPlayer {
+    private final String dumpCommandName;
+    private final String dumpedContentName;
+    private final DumpConverter dumpConverter;
+
+    public BotanyDump (String dumpCommandName, String dumpedContentName, DumpConverter dumpConverter) {
+
+        this.dumpCommandName = dumpCommandName;
+        this.dumpedContentName = dumpedContentName;
+        this.dumpConverter = dumpConverter;
+    }
+
+    @Override
+    public int executeCommand (PlayerEntity playerEntity, ItemStack itemStack) {
+
+        dumpToLog(playerEntity);
+        sendFeedBack(playerEntity);
+        return 0;
+    }
+
+    private void sendFeedBack (PlayerEntity player) {
+
+        final String format = "%sList of %s info generated! Check the crafttweaker.log file!%s";
+        final String message = String.format(format, TextFormatting.GREEN, dumpedContentName, TextFormatting.RESET);
+        final ITextComponent toSend = new StringTextComponent(message);
+
+        player.sendMessage(toSend, CraftTweaker.CRAFTTWEAKER_UUID);
+    }
+
+    private void dumpToLog (PlayerEntity player) {
+
+        final RecipeManager recipeManager = player.getEntityWorld().getRecipeManager();
+        final Set<ResourceLocation> locationsToDump = dumpConverter.getFromManager(recipeManager).keySet();
+
+        CraftTweakerAPI.logDump("List of all known %s:", dumpedContentName);
+
+        for (ResourceLocation location : locationsToDump) {
+            CraftTweakerAPI.logDump("- %s", location);
+        }
+    }
+
+    public void registerTo (CTCommandCollectionEvent event) {
+
+        final String description = getDescription();
+        event.registerDump(dumpCommandName, description, this);
+
+    }
+
+    private String getDescription () {
+
+        return String.format("Outputs all known %s names to the log.", dumpedContentName);
+    }
+
+    interface DumpConverter {
+        Map<ResourceLocation, ?> getFromManager (RecipeManager manager);
+    }
+}

--- a/src/main/java/net/darkhax/botanypots/addons/crt/CraftTweakerEventSubscription.java
+++ b/src/main/java/net/darkhax/botanypots/addons/crt/CraftTweakerEventSubscription.java
@@ -1,0 +1,37 @@
+package net.darkhax.botanypots.addons.crt;
+
+import com.blamejared.crafttweaker.impl.commands.CTCommandCollectionEvent;
+import com.blamejared.crafttweaker.impl.commands.script_examples.ExampleCollectionEvent;
+import net.darkhax.botanypots.BotanyPotHelper;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static net.darkhax.botanypots.BotanyPots.MOD_ID;
+
+public class CraftTweakerEventSubscription {
+
+    @SubscribeEvent
+    public static void addExampleScriptFiles (ExampleCollectionEvent event) {
+
+        event.addResource(new ResourceLocation(MOD_ID, "botanypots/crops"));
+        event.addResource(new ResourceLocation(MOD_ID, "botanypots/fertilizers"));
+        event.addResource(new ResourceLocation(MOD_ID, "botanypots/soils"));
+    }
+
+    @SubscribeEvent
+    public static void addDumpCommands (CTCommandCollectionEvent event) {
+
+        final Set<BotanyDump> dumps = new HashSet<>();
+
+        dumps.add(new BotanyDump("botanyCrops", "crops", BotanyPotHelper::getCropData));
+        dumps.add(new BotanyDump("botanyFertilizers", "fertilizers", BotanyPotHelper::getFertilizerData));
+        dumps.add(new BotanyDump("botanySoils", "soils", BotanyPotHelper::getSoilData));
+
+        for (BotanyDump dump : dumps) {
+            dump.registerTo(event);
+        }
+    }
+}

--- a/src/main/java/net/darkhax/botanypots/addons/crt/crops/Crops.java
+++ b/src/main/java/net/darkhax/botanypots/addons/crt/crops/Crops.java
@@ -1,64 +1,62 @@
 package net.darkhax.botanypots.addons.crt.crops;
 
-import org.openzen.zencode.java.ZenCodeType;
-
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
-import com.blamejared.crafttweaker.impl.blocks.MCBlockState;
-
 import net.darkhax.botanypots.BotanyPots;
 import net.darkhax.botanypots.crop.CropInfo;
+import net.minecraft.block.BlockState;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.ResourceLocation;
+import org.openzen.zencode.java.ZenCodeType;
 
 @ZenRegister
 @ZenCodeType.Name("mods.botanypots.Crops")
 public class Crops implements IRecipeManager {
-    
+
     public Crops() {
-        
+
         // This is needed for CraftTweaker
     }
-    
+
     @ZenCodeType.Method
-    public ZenCrop create (String id, IIngredient seed, MCBlockState display, int ticks, String categories) {
-        
-        return this.create(id, seed, new MCBlockState[] { display }, ticks, new String[] { categories });
+    public ZenCrop create (String id, IIngredient seed, BlockState display, int ticks, String categories) {
+
+        return this.create(id, seed, new BlockState[] { display }, ticks, new String[] { categories });
     }
-    
+
     @ZenCodeType.Method
-    public ZenCrop create (String id, IIngredient seed, MCBlockState[] display, int ticks, String[] categories) {
-        
+    public ZenCrop create (String id, IIngredient seed, BlockState[] display, int ticks, String[] categories) {
+
         final ZenCrop crop = new ZenCrop(id, seed, display, ticks, categories);
         CraftTweakerAPI.apply(new ActionAddRecipe(this, crop.getInternal(), ""));
         return crop;
     }
-    
+
     @ZenCodeType.Method
     public ZenCrop getCrop (String id) {
-        
+
         final IRecipe<?> info = this.getRecipes().get(ResourceLocation.tryCreate(id));
-        
+
         if (info instanceof CropInfo) {
             return new ZenCrop((CropInfo) info);
         }
-        
+
         throw new IllegalStateException("Invalid crop ID: " + id);
     }
-    
+
     @Override
     public ResourceLocation getBracketResourceLocation () {
-        
+
         return BotanyPots.instance.getContent().recipeSerializerCrop.getRegistryName();
     }
-    
+
     @Override
     public IRecipeType<?> getRecipeType () {
-        
+
         return BotanyPots.instance.getContent().recipeTypeCrop;
     }
 }

--- a/src/main/java/net/darkhax/botanypots/addons/crt/crops/Soils.java
+++ b/src/main/java/net/darkhax/botanypots/addons/crt/crops/Soils.java
@@ -1,5 +1,6 @@
 package net.darkhax.botanypots.addons.crt.crops;
 
+import net.minecraft.block.*;
 import org.openzen.zencode.java.ZenCodeType;
 
 import com.blamejared.crafttweaker.api.CraftTweakerAPI;
@@ -7,7 +8,6 @@ import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker.api.item.IIngredient;
 import com.blamejared.crafttweaker.api.managers.IRecipeManager;
 import com.blamejared.crafttweaker.impl.actions.recipes.ActionAddRecipe;
-import com.blamejared.crafttweaker.impl.blocks.MCBlockState;
 
 import net.darkhax.botanypots.BotanyPots;
 import net.darkhax.botanypots.soil.SoilInfo;
@@ -25,13 +25,13 @@ public class Soils implements IRecipeManager {
     }
     
     @ZenCodeType.Method
-    public ZenSoil create (String id, IIngredient ingredient, MCBlockState renderState, float growthModifier, String categories) {
+    public ZenSoil create (String id, IIngredient ingredient, BlockState renderState, float growthModifier, String categories) {
         
         return this.create(id, ingredient, renderState, growthModifier, new String[] { categories });
     }
     
     @ZenCodeType.Method
-    public ZenSoil create (String id, IIngredient ingredient, MCBlockState renderState, float growthModifier, String[] categories) {
+    public ZenSoil create (String id, IIngredient ingredient, BlockState renderState, float growthModifier, String[] categories) {
         
         final ZenSoil soil = new ZenSoil(id, ingredient, renderState, growthModifier, categories);
         CraftTweakerAPI.apply(new ActionAddRecipe(this, soil.getInternal(), ""));

--- a/src/main/java/net/darkhax/botanypots/addons/crt/crops/ZenCrop.java
+++ b/src/main/java/net/darkhax/botanypots/addons/crt/crops/ZenCrop.java
@@ -1,26 +1,15 @@
 package net.darkhax.botanypots.addons.crt.crops;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import com.blamejared.crafttweaker.api.annotations.*;
+import com.blamejared.crafttweaker.api.item.*;
+import net.darkhax.bookshelf.block.*;
+import net.darkhax.botanypots.crop.*;
+import net.minecraft.block.*;
+import net.minecraft.item.crafting.*;
+import net.minecraft.util.*;
+import org.openzen.zencode.java.*;
 
-import org.openzen.zencode.java.ZenCodeType;
-
-import com.blamejared.crafttweaker.api.annotations.ZenRegister;
-import com.blamejared.crafttweaker.api.item.IIngredient;
-import com.blamejared.crafttweaker.api.item.IItemStack;
-import com.blamejared.crafttweaker.impl.blocks.MCBlockState;
-
-import net.darkhax.bookshelf.block.DisplayableBlockState;
-import net.darkhax.botanypots.crop.CropInfo;
-import net.darkhax.botanypots.crop.HarvestEntry;
-import net.minecraft.block.BlockState;
-import net.minecraft.item.crafting.Ingredient;
-import net.minecraft.util.ResourceLocation;
+import java.util.*;
 
 @ZenRegister
 @ZenCodeType.Name("mods.botanypots.ZenCrop")
@@ -28,12 +17,12 @@ public class ZenCrop {
     
     private final CropInfo internal;
     
-    public ZenCrop(String id, IIngredient seed, MCBlockState[] display, int ticks, String[] categories, int lightLevel) {
+    public ZenCrop(String id, IIngredient seed, BlockState[] display, int ticks, String[] categories, int lightLevel) {
         
         this(new CropInfo(ResourceLocation.tryCreate(id), seed.asVanillaIngredient(), new HashSet<>(Arrays.asList(categories)), ticks, new ArrayList<>(), getBlockStates(display), Optional.of(lightLevel)));
     }
     
-    public ZenCrop(String id, IIngredient seed, MCBlockState[] display, int ticks, String[] categories) {
+    public ZenCrop(String id, IIngredient seed, BlockState[] display, int ticks, String[] categories) {
         
         this(new CropInfo(ResourceLocation.tryCreate(id), seed.asVanillaIngredient(), new HashSet<>(Arrays.asList(categories)), ticks, new ArrayList<>(), getBlockStates(display), Optional.empty()));
     }
@@ -113,14 +102,14 @@ public class ZenCrop {
     }
     
     @ZenCodeType.Method
-    public ZenCrop setDisplay (MCBlockState state) {
+    public ZenCrop setDisplay (BlockState state) {
         
         this.internal.setDisplayBlock(getBlockStates(state));
         return this;
     }
     
     @ZenCodeType.Method
-    public ZenCrop setDisplay (MCBlockState[] states) {
+    public ZenCrop setDisplay (BlockState[] states) {
         
         this.internal.setDisplayBlock(getBlockStates(states));
         return this;
@@ -138,23 +127,7 @@ public class ZenCrop {
         return this.internal;
     }
     
-    public static List<BlockState> getBlockStates (Collection<MCBlockState> states) {
-        
-        return states.stream().map(MCBlockState::getInternal).collect(Collectors.toList());
-    }
-    
-    public static List<MCBlockState> getMCBlockStates (Collection<BlockState> states) {
-        
-        return states.stream().map(MCBlockState::new).collect(Collectors.toList());
-    }
-    
-    public static DisplayableBlockState[] getBlockStates (MCBlockState... states) {
-        
-        return Arrays.stream(states).map(state -> new DisplayableBlockState(state.getInternal())).toArray(DisplayableBlockState[]::new);
-    }
-    
-    public static MCBlockState[] getMCBlockStates (BlockState... states) {
-        
-        return Arrays.stream(states).map(MCBlockState::new).toArray(MCBlockState[]::new);
+    public static DisplayableBlockState[] getBlockStates (BlockState... states) {
+        return Arrays.stream(states).map(DisplayableBlockState::new).toArray(DisplayableBlockState[]::new);
     }
 }

--- a/src/main/java/net/darkhax/botanypots/addons/crt/crops/ZenSoil.java
+++ b/src/main/java/net/darkhax/botanypots/addons/crt/crops/ZenSoil.java
@@ -4,11 +4,11 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 
+import net.minecraft.block.*;
 import org.openzen.zencode.java.ZenCodeType;
 
 import com.blamejared.crafttweaker.api.annotations.ZenRegister;
 import com.blamejared.crafttweaker.api.item.IIngredient;
-import com.blamejared.crafttweaker.impl.blocks.MCBlockState;
 
 import net.darkhax.botanypots.soil.SoilInfo;
 import net.minecraft.util.ResourceLocation;
@@ -19,14 +19,14 @@ public class ZenSoil {
     
     private final SoilInfo internal;
     
-    public ZenSoil(String id, IIngredient ingredient, MCBlockState renderState, float growthModifier, String[] categories, int lightLevel) {
+    public ZenSoil(String id, IIngredient ingredient, BlockState renderState, float growthModifier, String[] categories, int lightLevel) {
         
-        this(new SoilInfo(ResourceLocation.tryCreate(id), ingredient.asVanillaIngredient(), renderState.getInternal(), growthModifier, new HashSet<>(Arrays.asList(categories)), Optional.of(lightLevel)));
+        this(new SoilInfo(ResourceLocation.tryCreate(id), ingredient.asVanillaIngredient(), renderState, growthModifier, new HashSet<>(Arrays.asList(categories)), Optional.of(lightLevel)));
     }
     
-    public ZenSoil(String id, IIngredient ingredient, MCBlockState renderState, float growthModifier, String[] categories) {
+    public ZenSoil(String id, IIngredient ingredient, BlockState renderState, float growthModifier, String[] categories) {
         
-        this(new SoilInfo(ResourceLocation.tryCreate(id), ingredient.asVanillaIngredient(), renderState.getInternal(), growthModifier, new HashSet<>(Arrays.asList(categories)), Optional.empty()));
+        this(new SoilInfo(ResourceLocation.tryCreate(id), ingredient.asVanillaIngredient(), renderState, growthModifier, new HashSet<>(Arrays.asList(categories)), Optional.empty()));
     }
     
     public ZenSoil(SoilInfo info) {
@@ -63,9 +63,9 @@ public class ZenSoil {
     }
     
     @ZenCodeType.Method
-    public ZenSoil setDisplay (MCBlockState state) {
+    public ZenSoil setDisplay (BlockState state) {
         
-        this.internal.setRenderState(state.getInternal());
+        this.internal.setRenderState(state);
         return this;
     }
     
@@ -76,6 +76,7 @@ public class ZenSoil {
         return this;
     }
     
+    @ZenCodeType.Method
     public ZenSoil setLightLevel (int lightLevel) {
         
         this.internal.setLightLevel(lightLevel);

--- a/src/main/resources/data/botanypots/scripts/botanypots/crops.zs
+++ b/src/main/resources/data/botanypots/scripts/botanypots/crops.zs
@@ -1,0 +1,52 @@
+import mods.botanypots.ZenCrop;
+val crops = <recipetype:botanypots:crop>;
+
+// Simple crop entry
+// crops.create(id, seedInput, renderBlock, growthTicks, soilCategory);
+val goldCrop = crops.create("examplepack:gold", <item:minecraft:gold_nugget>, <blockstate:minecraft:gold_block>, 3000, "dirt");
+
+// Crop with multiple render blocks and multiple soil categories.
+// crops.create(id, seedInput, renderBlockArray, growthTicks, soilCategoryArray);
+val ironCrop = crops.create("examplepack:iron", <item:minecraft:iron_nugget>, [<blockstate:minecraft:iron_block>, <blockstate:minecraft:iron_ore>], 3000, ["dirt", "nether"]);
+
+
+val wheat = crops.getCrop("botanypots:crops/wheat");
+
+// Adds a soil category.
+wheat.addCategory("stone");
+
+// Removes a soil category.
+wheat.removeCategory("dirt");
+
+// Removes all soil categories.
+//wheat.clearCategories();
+
+// Adding new drop entries.
+// addDrop(item, chance);
+wheat.addDrop(<item:minecraft:gold_nugget>, 1); // 100% drop rate
+wheat.addDrop(<item:minecraft:gold_ingot>, 0.75); // 75% drop rate
+
+// addDrop(item, chance, rolls);
+wheat.addDrop(<item:minecraft:iron_nugget>, 1, 4); // 100% drop rate AND 4 attempts.
+
+// addDrop(item, chance, minRolls, maxRolls);
+wheat.addDrop(<item:minecraft:iron_ingot>, 0.75, 1, 5); // 75% drop rate AND 1 to 5 attempts.
+
+// Removes all drops.
+//wheat.clearDrops();
+
+// Removes a drop.
+// removeDrop(ingredientToRemove);
+wheat.removeDrop(<tag:items:forge:seeds>);
+
+// Set the growth ticks of the crop.
+wheat.setGrowthTicks(10000);
+
+// Sets the seed item.
+wheat.setSeed(<tag:items:forge:seeds/wheat>);
+
+// Sets the display block.
+wheat.setDisplay(<blockstate:minecraft:gold_block>);
+
+// Sets the display to multiple blocks stacked.
+wheat.setDisplay([<blockstate:minecraft:iron_block>, <blockstate:minecraft:iron_ore>]);

--- a/src/main/resources/data/botanypots/scripts/botanypots/fertilizers.zs
+++ b/src/main/resources/data/botanypots/scripts/botanypots/fertilizers.zs
@@ -1,0 +1,22 @@
+import mods.botanypots.ZenFertilizer;
+
+val fertilizers = <recipetype:botanypots:fertilizer>;
+
+
+
+// fertilizers.create(id, input, ticks);
+// fertilizers.create(id, input, minTicks, maxTicks);
+val stickFertilizer = fertilizers.create("examplepack:test", <item:minecraft:stick>, 1000);
+
+
+val bonemeal = fertilizers.getFertilizer("botanypots:fertilizers/bone_meal");
+
+// Set the input of the fertilizer.
+// setInput(input);
+bonemeal.setInput(<item:minecraft:stick>);
+
+// Sets the growth tick amount.
+// setGrowthAmount(ticks);
+// setGrowthAmount(min, max);
+
+bonemeal.setGrowthAmount(1200, 1500);

--- a/src/main/resources/data/botanypots/scripts/botanypots/soils.zs
+++ b/src/main/resources/data/botanypots/scripts/botanypots/soils.zs
@@ -1,0 +1,35 @@
+import mods.botanypots.ZenSoil;
+val soils = <recipetype:botanypots:soil>;
+
+
+// soils.create(id, input, renderBlock, growthModifier, category);
+// Growth can be any value less than or equal to 1. Higher = faster, 0 = no change.
+// category may also be a string array.
+val stoneSoil = soils.create("examplepack:stone", <tag:items:forge:stone>, <blockstate:minecraft:stone>, 0.15, "stone");
+
+
+val dirt = soils.getSoil("botanypots:soil/dirt");
+
+// Adds a category.
+// addCategory(category);
+dirt.addCategory("test");
+
+// Removes a category.
+// removeCategory(category);
+dirt.removeCategory("dirt");
+
+// Removes all categories.
+// clearCategories();
+dirt.clearCategories();
+
+// Sets the input.
+// setInput(input);
+dirt.setInput(<tag:items:forge:stone>);
+
+// Set display block.
+// setDisplay(state);
+dirt.setDisplay(<blockstate:minecraft:stone>);
+
+// Set growth modifier.
+// setGrowthModifier(modifier);
+dirt.setGrowthModifier(0.20);


### PR DESCRIPTION
Hey there,

since CraftTweaker will have some breaking changes in its API layer, here a PR fixing the arising issues.
Note that this version of CraftTweaker is not public yet, so in the interim this PR is marked as draft.

**Changes in this PR are:**
- Use vanilla types in the manager instead of wrapper types (which no longer exist)
- Add support for `/ct dump botanyCrops`, `botanySoil`, `botanyFertilizer`
- Add support for `/ct examples`, which will print a few example scripts into the `scripts/botanypots` folder (the scripts can be found in the data folder)

**Remarks:**
- The example files were taken from the [CraftTweaker-Support Wiki Page](https://github.com/Darkhax-Minecraft/BotanyPots/wiki/CraftTweaker-Support). I commented a few of the calls so that the scripts have a "noticeable" impact (so that they don't add and immediately after remove a drop, for example). If you have better examples, or wish for better comments on these files, please say so.
- Only tested in SinglePlayer. This PR does not touch the actual logic of how the actions are created nor applied, so I did not see a reason to test on a server. If you want me to test it there as well, please say so.
- I tried to import your codestyle file, but IDEA apparently didn't fully apply all of the rules, therefore a few imports are different. If I should change anything in that regards, please say so.