### PR TITLE
Add missing recipe conditions for Undergarden Shimmerweed

### DIFF
--- a/src/main/resources/data/undergarden/recipes/crops/shimmerweed.json
+++ b/src/main/resources/data/undergarden/recipes/crops/shimmerweed.json
@@ -1,5 +1,11 @@
 {
     "type": "botanypots:crop",
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "undergarden"
+        }
+    ],
     "seed": {
         "item": "undergarden:shimmerweed"
     },


### PR DESCRIPTION
The crop recipe json for shimmerweed from the undergarden was missing it's `mod_loaded` condition, causing a parsing error to appear in the log during world load