### PR TITLE
Drop soil & crop stack regardless of valid recipe

### DIFF
--- a/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
+++ b/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
@@ -332,8 +332,15 @@ public class BlockBotanyPot extends Block implements IGrowable, IWaterLoggable {
                 
                 final TileEntityBotanyPot pot = (TileEntityBotanyPot) tileEntity;
 
-                if (pot.getSoilStack() != ItemStack.EMPTY) dropItem(pot.getSoilStack(), worldIn, pos);
-                if (pot.getCropStack() != ItemStack.EMPTY) dropItem(pot.getCropStack(), worldIn, pos);
+                if (!pot.getSoilStack().isEmpty()) {
+
+                    dropItem(pot.getSoilStack(), worldIn, pos);
+                }
+
+                if (!pot.getCropStack().isEmpty()) {
+
+                    dropItem(pot.getCropStack(), worldIn, pos);
+                }
             }
         }
         

--- a/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
+++ b/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
@@ -331,16 +331,9 @@ public class BlockBotanyPot extends Block implements IGrowable, IWaterLoggable {
             if (tileEntity instanceof TileEntityBotanyPot) {
                 
                 final TileEntityBotanyPot pot = (TileEntityBotanyPot) tileEntity;
-                
-                if (pot.getSoil() != null) {
-                    
-                    dropItem(pot.getSoilStack(), worldIn, pos);
-                }
-                
-                if (pot.getCrop() != null) {
-                    
-                    dropItem(pot.getCropStack(), worldIn, pos);
-                }
+
+                if (pot.getSoilStack() != ItemStack.EMPTY) dropItem(pot.getSoilStack(), worldIn, pos);
+                if (pot.getCropStack() != ItemStack.EMPTY) dropItem(pot.getCropStack(), worldIn, pos);
             }
         }
         


### PR DESCRIPTION
During my [quest](https://github.com/EnigmaticaModpacks/Enigmatica6/pull/4858) to rename all `kjs_<random>` recipe ids it came to my attention that botany pots lock themselves to their recipe id & break if the recipe id gets renamed.

I'll be trying to figure out a clean way to make botany pots try to find a new recipe based on the stored soil & crop item stacks when it fails to unserialize, but at this point i have yet to come up with something.

Meanwhile this pull request makes it so that the botany pots always drop their soil & crop item stacks since they are still intact even when the recipe ids get cleared. this way no items get voided if a recipe gets removed or renamed.

Whilst the `if (pot.getSoilStack() != ItemStack.EMPTY)` check seems unnecessary since trying to drop the empty itemstack has no bad effects, i put the check in anyways for performance reasons so the math & drop attempt get skipped.

Note: this pull request is not a replacement for the other pull attempt i have hinted at above, but merely code that i feel like that should be there either way, since if the "recovery attempt" fails & as it is now: both itemstacks should still be dropping.