### PR TITLE
Recover soil/crop recipe ids from their respective itemstacks

### DIFF
--- a/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
+++ b/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
@@ -433,75 +433,66 @@ public class TileEntityBotanyPot extends TileEntityBasicTickable {
         this.soil = null;
         this.crop = null;
         
-        if (dataTag.contains("CropStack")) {
-            
-            this.cropStack = ItemStack.read(dataTag.getCompound("CropStack"));
-        }
-        
-        if (dataTag.contains("SoilStack")) {
-            
-            this.soilStack = ItemStack.read(dataTag.getCompound("SoilStack"));
-        }
-        
+        if (dataTag.contains("SoilStack")) this.soilStack = ItemStack.read(dataTag.getCompound("SoilStack"));
+        if (dataTag.contains("CropStack")) this.cropStack = ItemStack.read(dataTag.getCompound("CropStack"));
+
+        // Recover soil from id.
         if (dataTag.contains("Soil")) {
-            
             final String rawSoilId = dataTag.getString("Soil");
             ResourceLocation soilId = ResourceLocation.tryCreate(rawSoilId);
 
-            if(soilId == null) {
-                final SoilInfo recoveredSoil = BotanyPotHelper.getSoilForItem(soilStack);
-//                System.out.print(recoveredSoil);
-                if(recoveredSoil != null) {
-                    soilId = recoveredSoil.getId();
+            if (soilId == null) {
+                BotanyPots.LOGGER.error("Botany Pot at {} has invalid soil type {}. Soil and crop will be discarded.", this.pos, rawSoilId);
+            } else {
+                final SoilInfo foundSoil = BotanyPotHelper.getSoil(soilId);
+
+                if (foundSoil == null) {
+                    BotanyPots.LOGGER.error("Botany Pot at {} had a soil of type {} which no longer exists. Soil and crop will be discarded.", this.pos, rawSoilId);
                 } else {
-                    BotanyPots.LOGGER.error("Botany Pot at {} has invalid soil type {}. Soil and crop will be discarded.", this.pos, rawSoilId);
-                    return;
+                    this.soil = foundSoil;
                 }
-            }
-
-            final SoilInfo foundSoil = BotanyPotHelper.getSoil(soilId);
-
-            if(foundSoil == null) {
-                BotanyPots.LOGGER.error("Botany Pot at {} had a soil of type {} which no longer exists. Soil and crop will be discarded.", this.pos, rawSoilId);
-                return;
-            }
-                    
-            this.soil = foundSoil;
-
-            // Crops are only loaded if the soil exists.
-            if (dataTag.contains("Crop")) {
-
-                final String rawCropId = dataTag.getString("Crop");
-                ResourceLocation cropId = ResourceLocation.tryCreate(rawCropId);
-
-                if(cropId == null) {
-                    final CropInfo recoveredCrop = BotanyPotHelper.getCropForItem(cropStack);
-//                    System.out.print(recoveredCrop);
-                    if(recoveredCrop != null) {
-                        cropId = recoveredCrop.getId();
-                    } else {
-                        BotanyPots.LOGGER.error("Botany Pot at {} has an invalid crop Id of {}. The crop will be discarded.", this.pos, rawCropId);
-                        return;
-                    }
-                }
-
-                final CropInfo cropInfo = BotanyPotHelper.getCrop(cropId);
-
-                if(cropInfo == null) {
-                    BotanyPots.LOGGER.error("Botany Pot at {} had a crop of type {} but that crop does not exist. The crop will be discarded.", this.pos, rawCropId);
-                    return;
-                }
-
-                this.crop = cropInfo;
-
-                // Growth ticks are only loaded if a crop and soil exist.
-                this.currentGrowthTicks = dataTag.getInt("GrowthTicks");
-
-                // Reset total growth ticks on tile load to account for data
-                // changes.
-                this.totalGrowthTicks = this.crop.getGrowthTicksForSoil(this.soil);
             }
         }
+
+        // Recover soil from stack.
+        if (soil == null && this.soilStack != ItemStack.EMPTY) {
+            final SoilInfo recoveredSoil = BotanyPotHelper.getSoilForItem(soilStack);
+            if (recoveredSoil != null) this.soil = recoveredSoil;
+        }
+
+        // Crops are only loaded if the soil exists.
+        if(this.soil == null) return;
+
+        // Recover crop from id.
+        if (dataTag.contains("Crop")) {
+            final String rawCropId = dataTag.getString("Crop");
+            ResourceLocation cropId = ResourceLocation.tryCreate(rawCropId);
+
+            if(cropId == null){
+                BotanyPots.LOGGER.error("Botany Pot at {} has an invalid crop Id of {}. The crop will be discarded.", this.pos, rawCropId);
+            }else{
+                final CropInfo cropInfo = BotanyPotHelper.getCrop(cropId);
+                if(cropInfo == null){
+                    BotanyPots.LOGGER.error("Botany Pot at {} had a crop of type {} but that crop does not exist. The crop will be discarded.", this.pos, rawCropId);
+                }else{
+                    this.crop = cropInfo;
+                }
+            }
+        }
+
+        // Recover crop from stack.
+        if (crop == null && this.cropStack != ItemStack.EMPTY) {
+            final CropInfo recoveredCrop = BotanyPotHelper.getCropForItem(cropStack);
+            if (recoveredCrop != null) this.crop = recoveredCrop;
+        }
+
+        // Growth ticks are only loaded a crop exists too.
+        if(this.crop == null) return;
+
+        this.currentGrowthTicks = dataTag.contains("GrowthTicks") ? dataTag.getInt("GrowthTicks") : 0;
+
+        // Reset total growth ticks on tile load to account for data changes.
+        this.totalGrowthTicks = this.crop.getGrowthTicksForSoil(this.soil);
     }
     
     public ItemStack getSoilStack () {

--- a/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
+++ b/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
@@ -446,11 +446,17 @@ public class TileEntityBotanyPot extends TileEntityBasicTickable {
         if (dataTag.contains("Soil")) {
             
             final String rawSoilId = dataTag.getString("Soil");
-            final ResourceLocation soilId = ResourceLocation.tryCreate(rawSoilId);
+            ResourceLocation soilId = ResourceLocation.tryCreate(rawSoilId);
 
             if(soilId == null) {
-                BotanyPots.LOGGER.error("Botany Pot at {} has invalid soil type {}. Soil and crop will be discarded.", this.pos, rawSoilId);
-                return;
+                final SoilInfo recoveredSoil = BotanyPotHelper.getSoilForItem(soilStack);
+//                System.out.print(recoveredSoil);
+                if(recoveredSoil != null) {
+                    soilId = recoveredSoil.getId();
+                } else {
+                    BotanyPots.LOGGER.error("Botany Pot at {} has invalid soil type {}. Soil and crop will be discarded.", this.pos, rawSoilId);
+                    return;
+                }
             }
 
             final SoilInfo foundSoil = BotanyPotHelper.getSoil(soilId);
@@ -466,11 +472,17 @@ public class TileEntityBotanyPot extends TileEntityBasicTickable {
             if (dataTag.contains("Crop")) {
 
                 final String rawCropId = dataTag.getString("Crop");
-                final ResourceLocation cropId = ResourceLocation.tryCreate(rawCropId);
+                ResourceLocation cropId = ResourceLocation.tryCreate(rawCropId);
 
                 if(cropId == null) {
-                    BotanyPots.LOGGER.error("Botany Pot at {} has an invalid crop Id of {}. The crop will be discarded.", this.pos, rawCropId);
-                    return;
+                    final CropInfo recoveredCrop = BotanyPotHelper.getCropForItem(cropStack);
+//                    System.out.print(recoveredCrop);
+                    if(recoveredCrop != null) {
+                        cropId = recoveredCrop.getId();
+                    } else {
+                        BotanyPots.LOGGER.error("Botany Pot at {} has an invalid crop Id of {}. The crop will be discarded.", this.pos, rawCropId);
+                        return;
+                    }
                 }
 
                 final CropInfo cropInfo = BotanyPotHelper.getCrop(cropId);

--- a/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
+++ b/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
@@ -447,59 +447,47 @@ public class TileEntityBotanyPot extends TileEntityBasicTickable {
             
             final String rawSoilId = dataTag.getString("Soil");
             final ResourceLocation soilId = ResourceLocation.tryCreate(rawSoilId);
-            
-            if (soilId != null) {
-                
-                final SoilInfo foundSoil = BotanyPotHelper.getSoil(soilId);
-                
-                if (foundSoil != null) {
-                    
-                    this.soil = foundSoil;
-                    
-                    // Crops are only loaded if the soil exists.
-                    if (dataTag.contains("Crop")) {
-                        
-                        final String rawCropId = dataTag.getString("Crop");
-                        final ResourceLocation cropId = ResourceLocation.tryCreate(rawCropId);
-                        
-                        if (cropId != null) {
-                            
-                            final CropInfo cropInfo = BotanyPotHelper.getCrop(cropId);
-                            
-                            if (cropInfo != null) {
-                                
-                                this.crop = cropInfo;
-                                
-                                // Growth ticks are only loaded if a crop and soil exist.
-                                this.currentGrowthTicks = dataTag.getInt("GrowthTicks");
-                                
-                                // Reset total growth ticks on tile load to account for data
-                                // changes.
-                                this.totalGrowthTicks = this.crop.getGrowthTicksForSoil(this.soil);
-                            }
-                            
-                            else {
-                                
-                                BotanyPots.LOGGER.error("Botany Pot at {} had a crop of type {} but that crop does not exist. The crop will be discarded.", this.pos, rawCropId);
-                            }
-                        }
-                        
-                        else {
-                            
-                            BotanyPots.LOGGER.error("Botany Pot at {} has an invalid crop Id of {}. The crop will be discarded.", this.pos, rawCropId);
-                        }
-                    }
-                }
-                
-                else {
-                    
-                    BotanyPots.LOGGER.error("Botany Pot at {} had a soil of type {} which no longer exists. Soil and crop will be discarded.", this.pos, rawSoilId);
-                }
-            }
-            
-            else {
-                
+
+            if(soilId == null) {
                 BotanyPots.LOGGER.error("Botany Pot at {} has invalid soil type {}. Soil and crop will be discarded.", this.pos, rawSoilId);
+                return;
+            }
+
+            final SoilInfo foundSoil = BotanyPotHelper.getSoil(soilId);
+
+            if(foundSoil == null) {
+                BotanyPots.LOGGER.error("Botany Pot at {} had a soil of type {} which no longer exists. Soil and crop will be discarded.", this.pos, rawSoilId);
+                return;
+            }
+                    
+            this.soil = foundSoil;
+
+            // Crops are only loaded if the soil exists.
+            if (dataTag.contains("Crop")) {
+
+                final String rawCropId = dataTag.getString("Crop");
+                final ResourceLocation cropId = ResourceLocation.tryCreate(rawCropId);
+
+                if(cropId == null) {
+                    BotanyPots.LOGGER.error("Botany Pot at {} has an invalid crop Id of {}. The crop will be discarded.", this.pos, rawCropId);
+                    return;
+                }
+
+                final CropInfo cropInfo = BotanyPotHelper.getCrop(cropId);
+
+                if(cropInfo == null) {
+                    BotanyPots.LOGGER.error("Botany Pot at {} had a crop of type {} but that crop does not exist. The crop will be discarded.", this.pos, rawCropId);
+                    return;
+                }
+
+                this.crop = cropInfo;
+
+                // Growth ticks are only loaded if a crop and soil exist.
+                this.currentGrowthTicks = dataTag.getInt("GrowthTicks");
+
+                // Reset total growth ticks on tile load to account for data
+                // changes.
+                this.totalGrowthTicks = this.crop.getGrowthTicksForSoil(this.soil);
             }
         }
     }

--- a/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
+++ b/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
@@ -489,7 +489,7 @@ public class TileEntityBotanyPot extends TileEntityBasicTickable {
         // Growth ticks are only loaded a crop exists too.
         if(this.crop == null) return;
 
-        this.currentGrowthTicks = dataTag.contains("GrowthTicks") ? dataTag.getInt("GrowthTicks") : 0;
+        this.currentGrowthTicks = dataTag.getInt("GrowthTicks");
 
         // Reset total growth ticks on tile load to account for data changes.
         this.totalGrowthTicks = this.crop.getGrowthTicksForSoil(this.soil);

--- a/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
+++ b/src/main/java/net/darkhax/botanypots/block/tileentity/TileEntityBotanyPot.java
@@ -439,7 +439,7 @@ public class TileEntityBotanyPot extends TileEntityBasicTickable {
         // Recover soil from id.
         if (dataTag.contains("Soil")) {
             final String rawSoilId = dataTag.getString("Soil");
-            ResourceLocation soilId = ResourceLocation.tryCreate(rawSoilId);
+            final ResourceLocation soilId = ResourceLocation.tryCreate(rawSoilId);
 
             if (soilId == null) {
                 BotanyPots.LOGGER.error("Botany Pot at {} has invalid soil type {}. Soil and crop will be discarded.", this.pos, rawSoilId);
@@ -466,7 +466,7 @@ public class TileEntityBotanyPot extends TileEntityBasicTickable {
         // Recover crop from id.
         if (dataTag.contains("Crop")) {
             final String rawCropId = dataTag.getString("Crop");
-            ResourceLocation cropId = ResourceLocation.tryCreate(rawCropId);
+            final ResourceLocation cropId = ResourceLocation.tryCreate(rawCropId);
 
             if(cropId == null){
                 BotanyPots.LOGGER.error("Botany Pot at {} has an invalid crop Id of {}. The crop will be discarded.", this.pos, rawCropId);


### PR DESCRIPTION
> The attempt mentioned i would be making in #226

- If a valid soil id cannot be recovered from the data, only then will it try to get the soil from the respective itemstack
- If a valid crop id cannot be recovered from the data, only then will it try to get the crop from the respective itemstack

It appears to be able to recover from (temporarily) deleted json files and (temporarily) renamed json files. (& recompiling)

The messages written to `BotanyPots.LOGGER.error` aren't yet updated to reflect that the crop "might not" be discarded because of the new recovery attempt, before I touch this further I'll first await feedback from the author. (does he like it?)