### PR TITLE
Change growthTicks

### DIFF
--- a/Common/src/main/java/net/darkhax/botanypots/BotanyPotHelper.java
+++ b/Common/src/main/java/net/darkhax/botanypots/BotanyPotHelper.java
@@ -87,7 +87,7 @@ public class BotanyPotHelper {
             return false;
         }
 
-        return soil.canGrowCrop(level, pos, pot, crop) && crop.canGrowInSoil(level, pos, pot, soil);
+        return soil.canGrowCrop(level, pos, pot, crop) && crop.canGrowInSoil(level, pos, pot, soil) && crop.getGrowthTicks(level, pos, pot, soil) >= 0;
     }
 
     /**

--- a/Common/src/main/java/net/darkhax/botanypots/BotanyPotHelper.java
+++ b/Common/src/main/java/net/darkhax/botanypots/BotanyPotHelper.java
@@ -62,7 +62,7 @@ public class BotanyPotHelper {
         final float requiredGrowthTicks = crop.getGrowthTicks(level, pos, pot, soil);
         final float growthModifier = soil.getGrowthModifier(level, pos, pot, crop);
 
-        if (growthModifier >= 0) {
+        if (growthModifier >= 0 && requiredGrowthTicks >= 0) {
 
             return Mth.floor(requiredGrowthTicks / growthModifier);
         }

--- a/Common/src/main/java/net/darkhax/botanypots/data/recipes/crop/BasicCropSerializer.java
+++ b/Common/src/main/java/net/darkhax/botanypots/data/recipes/crop/BasicCropSerializer.java
@@ -2,6 +2,7 @@ package net.darkhax.botanypots.data.recipes.crop;
 
 import com.google.gson.JsonObject;
 import net.darkhax.bookshelf.api.serialization.Serializers;
+import net.darkhax.botanypots.Constants;
 import net.darkhax.botanypots.data.displaystate.DisplayState;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
@@ -26,8 +27,7 @@ public final class BasicCropSerializer implements RecipeSerializer<BasicCrop> {
         final List<DisplayState> states = DisplayState.SERIALIZER.fromJSONList(json, "display");
 
         if (growthTicks <= 0) {
-
-            throw new IllegalArgumentException("Crop " + id + " has an invalid growth tick rate. It must use a positive integer.");
+            Constants.LOG.warn("Crop {} has a negative growth tick rate. It will not be able to grow.", id);
         }
 
         return new BasicCrop(id, seed, validSoils, growthTicks, results, states, lightLevel);


### PR DESCRIPTION
growthTicks can now be negative. 

When negative, the plant will not grow or show in the pot.
This would fix issue #165 

two checks have been edited and a throwable has been changed to a log warn
