### PR TITLE
Added croptopia crop support (no saplings) #240

### DIFF
--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/artichoke.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/artichoke.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:artichoke_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:artichoke_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:artichoke"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:artichoke_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/artichoke.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/artichoke.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:artichoke_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/asparagus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/asparagus.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:asparagus_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/asparagus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/asparagus.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:asparagus_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:asparagus_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:asparagus"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:asparagus_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/barley.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/barley.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:barley_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:barley_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:barley"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:barley_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/barley.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/barley.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:barley_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/basil.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/basil.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:basil_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/basil.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/basil.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:basil_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:basil_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:basil"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:basil_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/bellpepper.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/bellpepper.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:bellpepper_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/bellpepper.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/bellpepper.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:bellpepper_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:bellpepper_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:bellpepper"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:bellpepper_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blackbean.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blackbean.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:blackbean_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:blackbean_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:blackbean"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:blackbean_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blackbean.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blackbean.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:blackbean_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blackberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blackberry.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:blackberry_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blackberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blackberry.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:blackberry_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:blackberry_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:blackberry"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:blackberry_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blueberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blueberry.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:blueberry_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:blueberry_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:blueberry"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:blueberry_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blueberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/blueberry.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:blueberry_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/broccoli.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/broccoli.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:broccoli_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/broccoli.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/broccoli.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:broccoli_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:broccoli_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:broccoli"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:broccoli_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cabbage.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cabbage.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:cabbage_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cabbage.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cabbage.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:cabbage_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:cabbage_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:cabbage"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:cabbage_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cantaloupe.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cantaloupe.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:cantaloupe_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:cantaloupe_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:cantaloupe"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:cantaloupe_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cantaloupe.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cantaloupe.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:cantaloupe_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cauliflower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cauliflower.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:cauliflower_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cauliflower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cauliflower.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:cauliflower_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:cauliflower_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:cauliflower"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:cauliflower_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/celery.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/celery.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:celery_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:celery_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:celery"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:celery_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/celery.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/celery.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:celery_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/chile_pepper.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/chile_pepper.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:chile_pepper_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/chile_pepper.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/chile_pepper.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:chile_pepper_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:chile_pepper_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:chile_pepper"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:chile_pepper_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/coffee.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/coffee.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:coffee_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:coffee_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:coffee_beans"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:coffee_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/coffee.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/coffee.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:coffee_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/corn.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/corn.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:corn_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/corn.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/corn.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:corn_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:corn_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:corn"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:corn_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cranberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cranberry.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:cranberry_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cranberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cranberry.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:cranberry_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:cranberry_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:cranberry"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:cranberry_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cucumber.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cucumber.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:cucumber_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:cucumber_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:cucumber"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:cucumber_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cucumber.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/cucumber.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:cucumber_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/currant.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/currant.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:currant_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/currant.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/currant.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:currant_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:currant_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:currant"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:currant_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/eggplant.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/eggplant.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:eggplant_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:eggplant_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:eggplant"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:eggplant_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/eggplant.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/eggplant.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:eggplant_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/elderberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/elderberry.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:elderberry_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/elderberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/elderberry.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:elderberry_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:elderberry_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:elderberry"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:elderberry_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/garlic.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/garlic.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:garlic_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:garlic_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:garlic"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:garlic_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/garlic.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/garlic.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:garlic_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/ginger.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/ginger.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:ginger_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:ginger_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:ginger"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:ginger_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/ginger.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/ginger.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:ginger_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/grape.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/grape.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:grape_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:grape_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:grape"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:grape_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/grape.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/grape.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:grape_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/greenbean.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/greenbean.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:greenbean_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/greenbean.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/greenbean.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:greenbean_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:greenbean_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:greenbean"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:greenbean_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/greenonion.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/greenonion.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:greenonion_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/greenonion.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/greenonion.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:greenonion_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:greenonion_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:greenonion"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:greenonion_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/honeydew.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/honeydew.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:honeydew_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:honeydew_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:honeydew"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:honeydew_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/honeydew.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/honeydew.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:honeydew_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/hops.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/hops.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:hops_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/hops.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/hops.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:hops_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:hops_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:hops"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:hops_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/kale.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/kale.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:kale_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/kale.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/kale.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:kale_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:kale_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:kale"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:kale_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/kiwi.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/kiwi.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:kiwi_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/kiwi.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/kiwi.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:kiwi_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:kiwi_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:kiwi"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:kiwi_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/leek.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/leek.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:leek_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:leek_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:leek"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:leek_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/leek.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/leek.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:leek_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/lettuce.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/lettuce.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:lettuce_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/lettuce.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/lettuce.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:lettuce_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:lettuce_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:lettuce"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:lettuce_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/mustard.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/mustard.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:mustard_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/mustard.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/mustard.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:mustard_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:mustard_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:mustard"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:mustard_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/oat.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/oat.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:oat_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:oat_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:oat"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:oat_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/oat.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/oat.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:oat_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/olive.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/olive.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:olive_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/olive.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/olive.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:olive_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:olive_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:olive"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:olive_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/onion.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/onion.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:onion_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/onion.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/onion.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:onion_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:onion_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:onion"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:onion_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/peanut.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/peanut.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:peanut_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:peanut_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:peanut"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:peanut_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/peanut.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/peanut.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:peanut_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/pepper.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/pepper.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:pepper_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/pepper.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/pepper.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:pepper_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:pepper_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:pepper"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:pepper_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/pineapple.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/pineapple.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:pineapple_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/pineapple.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/pineapple.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:pineapple_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:pineapple_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:pineapple"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:pineapple_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/radish.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/radish.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:radish_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/radish.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/radish.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:radish_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:radish_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:radish"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:radish_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/raspberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/raspberry.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:raspberry_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/raspberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/raspberry.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:raspberry_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:raspberry_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:raspberry"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:raspberry_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rhubarb.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rhubarb.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:rhubarb_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:rhubarb_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:rhubarb"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:rhubarb_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rhubarb.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rhubarb.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:rhubarb_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rice.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rice.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:rice_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:rice_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:rice"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:rice_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rice.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rice.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:rice_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rutabaga.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rutabaga.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:rutabaga_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rutabaga.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/rutabaga.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:rutabaga_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:rutabaga_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:rutabaga"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:rutabaga_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/saguaro.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/saguaro.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:saguaro_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:saguaro_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:saguaro"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:saguaro_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/saguaro.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/saguaro.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:saguaro_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/soybean.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/soybean.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:soybean_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/soybean.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/soybean.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:soybean_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:soybean_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:soybean"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:soybean_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/spinach.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/spinach.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:spinach_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:spinach_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:spinach"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:spinach_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/spinach.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/spinach.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:spinach_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/squash.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/squash.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:squash_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:squash_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:squash"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:squash_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/squash.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/squash.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:squash_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/strawberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/strawberry.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:strawberry_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:strawberry_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:strawberry"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:strawberry_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/strawberry.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/strawberry.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:strawberry_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/sweetpotato.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/sweetpotato.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:sweetpotato_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:sweetpotato_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:sweetpotato"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:sweetpotato_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/sweetpotato.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/sweetpotato.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:sweetpotato_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tea_leaves.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tea_leaves.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:tea_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tea_leaves.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tea_leaves.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:tea_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:tea_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:tea_leaves"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:tea_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tomatillo.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tomatillo.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:tomatillo_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:tomatillo_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:tomatillo"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:tomatillo_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tomatillo.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tomatillo.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:tomatillo_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tomato.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tomato.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:tomato_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tomato.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/tomato.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:tomato_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:tomato_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:tomato"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:tomato_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/turmeric.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/turmeric.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:turmeric_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:turmeric_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:turmeric"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:turmeric_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/turmeric.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/turmeric.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:turmeric_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/turnip.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/turnip.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:turnip_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:turnip_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:turnip"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:turnip_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/turnip.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/turnip.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:turnip_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/vanilla.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/vanilla.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:vanilla_seeds"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:vanilla_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:vanilla"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:vanilla_seeds"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/vanilla.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/vanilla.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:vanilla_seeds"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/yam.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/yam.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:yam_seed"
+            ]
         }
     ]
 }

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/yam.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/yam.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:yam_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:yam_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:yam"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:yam_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/zucchini.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/zucchini.json
@@ -1,0 +1,39 @@
+{
+    "type": "botanypots:crop",
+    "seed": {
+        "item": "croptopia:zucchini_seed"
+    },
+    "categories": [
+        "dirt",
+        "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+        "type": "botanypots:aging",
+        "block": "croptopia:zucchini_crop"
+    },
+    "drops": [
+        {
+            "chance": 1,
+            "output": {
+                "item": "croptopia:zucchini"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+        },
+        {
+            "chance": 0.05,
+            "output": {
+                "item": "croptopia:zucchini_seed"
+            },
+            "minRolls": 1,
+            "maxRolls": 1
+        }
+    ],
+    "conditions": [
+        {
+            "type": "forge:mod_loaded",
+            "modid": "croptopia"
+        }
+    ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/zucchini.json
+++ b/Common/src/main/resources/data/botanypots/recipes/croptopia/crop/zucchini.json
@@ -30,10 +30,12 @@
             "maxRolls": 1
         }
     ],
-    "conditions": [
+    "bookshelf:load_conditions": [
         {
-            "type": "forge:mod_loaded",
-            "modid": "croptopia"
+            "type": "bookshelf:item_exists",
+            "values": [
+                "croptopia:zucchini_seed"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Hi,

I'm not a Java developer, but I saw that mod support depends mostly on datapacks. Croptopia already has recipes for the [Industrial Engineering Cloche](https://github.com/ExcessiveAmountsOfZombies/Croptopia/tree/1.19/forge/src/main/resources/data/croptopia/recipes/ie_cloche), so I wrote a script to translate the format to the BotanyPot structure. They all follow the same basic template, which I based off wheat with a lower seed chance. The tea and pepper crops needed to be hand added, due to a minor omission in the IE integration.

I tested the same stuff as this pull request in a data pack on a single player, creative world. I planted all the standard Croptopia seeds in pots to test, and they all work successfully. (I actually tested this atop the ATM8 mod pack.)

I plan to figure out how to do the same for BotanyTrees, but don't have time tonight. I hope this helps. :smile: