### PR TITLE
Allow addons to change the pot_type

### DIFF
--- a/Common/src/main/java/net/darkhax/botanypots/Content.java
+++ b/Common/src/main/java/net/darkhax/botanypots/Content.java
@@ -61,7 +61,7 @@ public class Content extends RegistryDataProvider {
             this.blocks.add(() -> new BlockBotanyPot(properties, true), color.getName() + "_glazed_terracotta_hopper_botany_pot");
         }
 
-        this.blockEntities.add(() -> Services.CONSTRUCTS.blockEntityType(BlockEntityBotanyPot::new, this::getAllPots).get(), "botany_pot");
+        this.blockEntities.add(() -> Services.CONSTRUCTS.blockEntityType((pos, state) -> new BlockEntityBotanyPot(BlockEntityBotanyPot.POT_TYPE.get(), pos, state), this::getAllPots).get(), "botany_pot");
         this.menus.add(() -> Services.CONSTRUCTS.menuType(BotanyPotMenu::fromNetwork), "pot_menu");
     }
 

--- a/Common/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
+++ b/Common/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
@@ -118,7 +118,7 @@ public class BlockBotanyPot extends InventoryBlock implements SimpleWaterloggedB
     @Override
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
 
-        return new BlockEntityBotanyPot(pos, state);
+        return new BlockEntityBotanyPot(BlockEntityBotanyPot.POT_TYPE.get(), pos, state);
     }
 
     @Override

--- a/Common/src/main/java/net/darkhax/botanypots/block/BlockEntityBotanyPot.java
+++ b/Common/src/main/java/net/darkhax/botanypots/block/BlockEntityBotanyPot.java
@@ -49,9 +49,9 @@ public class BlockEntityBotanyPot extends WorldlyInventoryBlockEntity<BotanyPotC
     final Random rng = new Random();
     private long rngSeed;
 
-    public BlockEntityBotanyPot(BlockPos pos, BlockState state) {
+    public BlockEntityBotanyPot(BlockEntityType potType, BlockPos pos, BlockState state) {
 
-        super(POT_TYPE.get(), pos, state);
+        super(potType, pos, state);
         this.refreshRandom();
     }
 


### PR DESCRIPTION
I am the creator of the [Botany Pots Tiers](https://www.curseforge.com/minecraft/mc-mods/botany-pots-tiers) mod and I wanted to extend the BlockEntityBotanyPot class because I want that every recipe from the original Botany Pots mod to be synced over to the addon (like in 1.16.5). The only problem was that I couldn't change the POT_TYPE because it was hardcoded in the TileEntity class