### PR TITLE
Cherrypick "Support REI on Fabric" to 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,13 +59,8 @@ subprojects {
         }
 
         maven {
-            name = 'BlameJared Maven (CrT / Bookshelf)'
+            name = 'BlameJared Maven (CrT / Bookshelf / JEI)'
             url = 'https://maven.blamejared.com'
-        }
-
-        maven {
-            name = 'Progwml6 Maven (JEI)'
-            url = 'https://dvs1.progwml6.com/files/maven/'
         }
 
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,11 @@ subprojects {
             name = 'Progwml6 Maven (JEI)'
             url = 'https://dvs1.progwml6.com/files/maven/'
         }
+
+        maven {
+            name = 'shedaniel Maven (REI)'
+            url = 'https://maven.shedaniel.me/'
+        }
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
     compileOnly group: 'net.darkhax.bookshelf', name: "Bookshelf-Common-${minecraft_version}", version: bookshelf_version
     compileOnly group: 'mezz.jei', name: "jei-${minecraft_version}-common-api", version: jei_version
+    compileOnly group: 'me.shedaniel', name: "RoughlyEnoughItems-api-forge", version: rei_version
 }
 
 processResources {

--- a/common/src/main/java/net/darkhax/botanypots/addons/rei/CropDisplayCategory.java
+++ b/common/src/main/java/net/darkhax/botanypots/addons/rei/CropDisplayCategory.java
@@ -1,0 +1,51 @@
+package net.darkhax.botanypots.addons.rei;
+
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.Renderer;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.darkhax.botanypots.Constants;
+import net.darkhax.botanypots.addons.rei.ui.CropDisplay;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
+
+public class CropDisplayCategory implements DisplayCategory<CropDisplay> {
+
+    private final CategoryIdentifier<CropDisplay> id;
+    private final Component localizedName;
+    
+    public CropDisplayCategory(CategoryIdentifier<CropDisplay> id) {
+
+        this.id = id;
+        this.localizedName = Component.translatable("gui.jei.category.botanypots.crop");
+    }
+    
+    @Override
+    public CategoryIdentifier<? extends CropDisplay> getCategoryIdentifier() {
+
+        return this.id;
+    }
+    
+    @Override
+    public Component getTitle() {
+
+        return this.localizedName;
+    }
+    
+    @Override
+    public Renderer getIcon() {
+
+        return EntryStacks.of(BuiltInRegistries.ITEM.get(new ResourceLocation(Constants.MOD_ID, "terracotta_botany_pot")));
+    }
+    
+    @Override
+    public List<Widget> setupDisplay(CropDisplay display, Rectangle bounds) {
+
+        return display.setupDisplay(bounds);
+    }
+}

--- a/common/src/main/java/net/darkhax/botanypots/addons/rei/REIPlugin.java
+++ b/common/src/main/java/net/darkhax/botanypots/addons/rei/REIPlugin.java
@@ -1,0 +1,64 @@
+package net.darkhax.botanypots.addons.rei;
+
+import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
+import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.EntryStacks;
+import net.darkhax.botanypots.BotanyPotHelper;
+import net.darkhax.botanypots.BotanyPotsCommon;
+import net.darkhax.botanypots.Constants;
+import net.darkhax.botanypots.addons.rei.ui.BasicCropDisplay;
+import net.darkhax.botanypots.addons.rei.ui.CropDisplay;
+import net.darkhax.botanypots.block.BlockBotanyPot;
+import net.darkhax.botanypots.data.recipes.crop.BasicCrop;
+import net.darkhax.botanypots.data.recipes.crop.Crop;
+import net.darkhax.botanypots.data.recipes.soil.Soil;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.crafting.RecipeManager;
+
+import java.util.List;
+
+public class REIPlugin implements REIClientPlugin {
+    public static final CategoryIdentifier<CropDisplay> SOIL = CategoryIdentifier.of(Constants.MOD_ID, "soil");
+    public static final CategoryIdentifier<CropDisplay> CROP = CategoryIdentifier.of(Constants.MOD_ID, "crop");
+
+    @Override
+    public void registerCategories(CategoryRegistry registry) {
+
+        registry.add(new CropDisplayCategory(SOIL));
+        registry.add(new CropDisplayCategory(CROP));
+
+        EntryIngredient.Builder builder = EntryIngredient.builder();
+
+        for (Item potItem : BotanyPotsCommon.content.items) {
+            if (potItem instanceof BlockItem blockItem && blockItem.getBlock() instanceof BlockBotanyPot pot) {
+                builder.add(EntryStacks.of(potItem));
+            }
+        }
+
+        registry.addWorkstations(CROP, builder.build());
+    }
+
+    @Override
+    public void registerDisplays(DisplayRegistry registry) {
+
+        final RecipeManager recipeManager = registry.getRecipeManager();
+        final List<Soil> soils = BotanyPotHelper.getAllRecipes(recipeManager, BotanyPotHelper.SOIL_TYPE.get());
+        final List<Crop> crops = BotanyPotHelper.getAllRecipes(recipeManager, BotanyPotHelper.CROP_TYPE.get());
+
+        crops.forEach(crop -> {
+
+            if (crop instanceof BasicCrop basic) {
+                List<CropDisplay> displays = BasicCropDisplay.getCropRecipes(basic, soils);
+
+                for (CropDisplay display : displays) {
+
+                    registry.add(display, basic);
+                }
+            }
+        });
+    }
+}

--- a/common/src/main/java/net/darkhax/botanypots/addons/rei/ui/BasicCropDisplay.java
+++ b/common/src/main/java/net/darkhax/botanypots/addons/rei/ui/BasicCropDisplay.java
@@ -1,0 +1,172 @@
+package net.darkhax.botanypots.addons.rei.ui;
+
+import me.shedaniel.math.Point;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.widgets.Slot;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.client.gui.widgets.Widgets;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
+import me.shedaniel.rei.api.common.entry.EntryIngredient;
+import me.shedaniel.rei.api.common.util.CollectionUtils;
+import me.shedaniel.rei.api.common.util.EntryIngredients;
+import net.darkhax.botanypots.BotanyPotHelper;
+import net.darkhax.botanypots.addons.rei.REIPlugin;
+import net.darkhax.botanypots.data.recipes.crop.BasicCrop;
+import net.darkhax.botanypots.data.recipes.crop.HarvestEntry;
+import net.darkhax.botanypots.data.recipes.soil.BasicSoil;
+import net.darkhax.botanypots.data.recipes.soil.Soil;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Ingredient;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class BasicCropDisplay extends BasicDisplay implements CropDisplay {
+
+    private static final DecimalFormat FORMAT = new DecimalFormat("#.##");
+    private final List<HarvestEntry> drops;
+    private final int growthTime;
+    private final float modifier;
+
+    public static List<CropDisplay> getCropRecipes(BasicCrop crop, List<Soil> soils) {
+
+        final List<CropDisplay> info = new ArrayList<>();
+
+        for (Soil soil : soils) {
+
+            if (soil instanceof BasicSoil basicSoil && crop.canGrowInSoil(null, null, null, soil)) {
+
+                final int ticks = BotanyPotHelper.getRequiredGrowthTicks(null, null, null, crop, soil);
+                info.add(new BasicCropDisplay(crop.getId(), crop.getSeed(), basicSoil.getIngredient(), crop.getResults(), ticks, basicSoil.getGrowthModifier()));
+            }
+        }
+
+        return info;
+    }
+
+    public BasicCropDisplay(ResourceLocation id, Ingredient seed, Ingredient soil, List<HarvestEntry> drops, int growthTime, float modifier) {
+
+        this(id, List.of(seed), List.of(soil), drops, growthTime, modifier);
+    }
+
+    public BasicCropDisplay(ResourceLocation id, List<Ingredient> seeds, List<Ingredient> soils, List<HarvestEntry> drops, int growthTime, float modifier) {
+        super(List.of(reiIngredientFromIngredients(seeds), reiIngredientFromIngredients(soils)),
+                reiIngredientsFromDrops(drops), Optional.ofNullable(id));
+        this.drops = drops;
+        this.growthTime = growthTime;
+        this.modifier = modifier;
+    }
+
+    private static EntryIngredient reiIngredientFromIngredients(List<Ingredient> seeds) {
+        return EntryIngredients.ofItemStacks(CollectionUtils.flatMap(seeds, ingredient -> Arrays.asList(ingredient.getItems())));
+    }
+
+    private static List<EntryIngredient> reiIngredientsFromDrops(List<HarvestEntry> drops) {
+        return CollectionUtils.map(drops, entry -> EntryIngredients.of(entry.getItem()));
+    }
+
+    public float getModifier() {
+        return modifier;
+    }
+
+    public int getGrowthTime() {
+        return growthTime;
+    }
+
+    @Override
+    public CategoryIdentifier<?> getCategoryIdentifier() {
+        return REIPlugin.CROP;
+    }
+
+    @Override
+    public List<Widget> setupDisplay(Rectangle bounds) {
+
+        List<EntryIngredient> inputEntries = this.getInputEntries();
+        List<EntryIngredient> outputEntries = this.getOutputEntries();
+        List<Widget> widgets = new ArrayList<>();
+        
+        widgets.add(Widgets.createRecipeBase(bounds));
+
+        // Seeds
+        widgets.add(Widgets.createSlot(new Point(bounds.x + 34, bounds.y + 16))
+                .markInput()
+                .entries(inputEntries.get(0).map(stack -> stack.tooltip(getSeedTooltip())))
+        );
+
+        // Soils
+        widgets.add(Widgets.createSlot(new Point(bounds.x + 34, bounds.y + 34))
+                .markInput()
+                .entries(inputEntries.get(1).map(stack -> stack.tooltip(getSoilTooltip())))
+        );
+
+        // Drops
+
+        int dropCount = 0;
+
+        for (int i = 0; i < 12; i++) {
+            Slot slot = Widgets.createSlot(new Point(bounds.x + 73 + 18 * (dropCount % 4), bounds.y + 7 + (18 * (dropCount / 4))))
+                    .markOutput();
+            widgets.add(slot);
+
+            if (i < outputEntries.size()) {
+                Component[] dropTooltip = getDropTooltip(this.drops.get(dropCount));
+                slot.entries(outputEntries.get(i).map(stack -> stack.tooltip(dropTooltip)));
+            }
+
+            dropCount++;
+        }
+
+        return widgets;
+    }
+
+    private Component[] getSeedTooltip() {
+
+        return new Component[]{
+                Component.translatable("tooltip.botanypots.grow_time", ticksToTime(this.growthTime)).withStyle(ChatFormatting.GRAY)
+        };
+    }
+
+    private Component[] getSoilTooltip() {
+
+        return new Component[]{
+                Component.translatable("tooltip.botanypots.modifier", FORMAT.format(this.modifier)).withStyle(ChatFormatting.GRAY)
+        };
+    }
+
+    private Component[] getDropTooltip(HarvestEntry drops) {
+
+        final int rollMin = drops.getMinRolls();
+        final int rollMax = drops.getMaxRolls();
+
+        Component rolls;
+
+        if (rollMin == rollMax) {
+
+            rolls = Component.translatable("tooltip.botanypots.rolls", rollMin).withStyle(ChatFormatting.GRAY);
+        } else {
+
+            rolls = Component.translatable("tooltip.botanypots.rollrange", rollMin, rollMax).withStyle(ChatFormatting.GRAY);
+        }
+
+        return new Component[]{
+                Component.translatable("tooltip.botanypots.chance", FORMAT.format(drops.getChance() * 100f)).withStyle(ChatFormatting.GRAY),
+                rolls
+        };
+    }
+
+    private static String ticksToTime(int ticks) {
+
+        ticks = Math.abs(ticks);
+        int i = ticks / 20;
+        final int j = i / 60;
+        i = i % 60;
+
+        return i < 10 ? j + ":0" + i : j + ":" + i;
+    }
+}

--- a/common/src/main/java/net/darkhax/botanypots/addons/rei/ui/CropDisplay.java
+++ b/common/src/main/java/net/darkhax/botanypots/addons/rei/ui/CropDisplay.java
@@ -1,0 +1,12 @@
+package net.darkhax.botanypots.addons.rei.ui;
+
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.widgets.Widget;
+import me.shedaniel.rei.api.common.display.Display;
+
+import java.util.List;
+
+public interface CropDisplay extends Display {
+
+    List<Widget> setupDisplay(Rectangle bounds);
+}

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     modImplementation "net.darkhax.bookshelf:Bookshelf-Fabric-${minecraft_version}:${bookshelf_version}"
     modImplementation "mezz.jei:jei-${minecraft_version}-fabric:${jei_version}"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:${rei_version}"
 
     implementation project(':common')
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -28,6 +28,9 @@
     ],
     "jei_mod_plugin": [
       "net.darkhax.botanypots.addons.jei.JEIPlugin"
+    ],
+    "rei_client": [
+      "net.darkhax.botanypots.addons.rei.REIPlugin"
     ]
   },
   "depends": {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -72,11 +72,19 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     implementation fg.deobf("net.darkhax.bookshelf:Bookshelf-Forge-${project.ext.minecraft_version}:${project.ext.bookshelf_version}")
     implementation fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
+    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-api-forge:${rei_version}")
+    compileOnly fg.deobf("dev.architectury:architectury-forge:8.1.87") // It doesn't actually matter which version we use as this is compileOnly
+    compileOnly fg.deobf("me.shedaniel.cloth:cloth-config-forge:10.0.96") // It doesn't actually matter which version we use as this is compileOnly
     compileOnly fg.deobf("curse.maven:top-245211:${top_version}")
 
     compileOnly project(':common')
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+}
+
+configurations {
+    // Fails without this as compileOnly dependencies do not get added to the test classpath
+    testCompileOnly.extendsFrom compileOnly
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ group=net.darkhax.botanypots
 minecraft_version=1.20.1
 bookshelf_version=20.0.1
 jei_version=15.2.0.23
+rei_version=12.0.645
 
 # Forge
 forge_version=47.1.28


### PR DESCRIPTION
To resolve #331 
Changed rei_version to 12.0.645

Also removed Progwm16's Maven repo. JEI is now on BlameJared's Maven as per [JEI wiki](https://github.com/mezz/JustEnoughItems/wiki/Getting-Started-%5BJEI-10-or-higher-for-Forge-or-Fabric%5D#repositories) (I wasn't able to get it to build without this change)

I've built and tested the Fabric version on 1.20.1