### PR TITLE
(1.19.2+) Add support for various different mods

### DIFF
--- a/Common/src/main/resources/data/botanypots/recipes/aether/crop/purple_flower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether/crop/purple_flower.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether:purple_flower"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether:purple_flower"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether:purple_flower"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether:purple_flower"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether/crop/white_flower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether/crop/white_flower.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether:white_flower"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether:white_flower"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether:white_flower"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether:white_flower"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether/soil/aether_dirt.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether/soil/aether_dirt.json
@@ -1,0 +1,20 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "aether:aether_dirt"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "aether:aether_dirt"
+    },
+    "display": {
+      "block": "aether:aether_dirt"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt"
+    ],
+    "growthModifier": 1.00
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether/soil/aether_farmland.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether/soil/aether_farmland.json
@@ -1,0 +1,22 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "aether:aether_farmland"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "aether:aether_farmland"
+    },
+    "display": {
+      "block": "aether:aether_farmland"
+    },
+    "categories": [
+      "dirt",
+      "aether_dirt",
+      "aether_farmland",
+      "farmland"
+    ],
+    "growthModifier": 1.00
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether/soil/aether_grass.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether/soil/aether_grass.json
@@ -1,0 +1,22 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "aether:aether_grass_block"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "aether:aether_grass_block"
+    },
+    "display": {
+      "block": "aether:aether_grass_block"
+    },
+    "categories": [
+      "grass",
+      "dirt",
+      "aether_dirt",
+      "aether_grass"
+    ],
+    "growthModifier": 1.00
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/aurum.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/aurum.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:aurum"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:aurum"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:aurum"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:aurum"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/blightshade.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/blightshade.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:blightshade"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:blightshade"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:blightshade"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:blightshade"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/daggerbloom.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/daggerbloom.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:daggerbloom"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:daggerbloom"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:daggerbloom"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:daggerbloom"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/firecap.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/firecap.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:firecap"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:firecap"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:firecap"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:firecap"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/frosted_purple_flower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/frosted_purple_flower.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:frosted_purple_flower"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:frosted_purple_flower"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:frosted_purple_flower"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:frosted_purple_flower"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/gilded_white_flower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/gilded_white_flower.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:gilded_white_flower"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:gilded_white_flower"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:gilded_white_flower"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:gilded_white_flower"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/golden_clover.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/golden_clover.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:golden_clover"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:golden_clover"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:golden_clover"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:golden_clover"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/iridia.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/iridia.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:iridia"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:iridia"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:iridia"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:iridia"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/spirolyctil.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/spirolyctil.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:spirolyctil"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:spirolyctil"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:spirolyctil"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:spirolyctil"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/sweetblossom.json
+++ b/Common/src/main/resources/data/botanypots/recipes/aether_redux/crop/sweetblossom.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "aether_redux:sweetblossom"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "aether_redux:sweetblossom"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "aether_redux:sweetblossom"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "aether_redux:sweetblossom"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/blueskies/soil/lunar_farmland.json
+++ b/Common/src/main/resources/data/botanypots/recipes/blueskies/soil/lunar_farmland.json
@@ -1,0 +1,20 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "blue_skies:lunar_farmland"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "blue_skies:lunar_farmland"
+    },
+    "display": {
+      "block": "blue_skies:lunar_farmland"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthModifier": 1.10
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/blueskies/soil/turquoise_farmland.json
+++ b/Common/src/main/resources/data/botanypots/recipes/blueskies/soil/turquoise_farmland.json
@@ -1,0 +1,20 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "blue_skies:turquoise_farmland"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "blue_skies:turquoise_farmland"
+    },
+    "display": {
+      "block": "blue_skies:turquoise_farmland"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthModifier": 1.10
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/blueskies/soil/turquoise_farmland.json
+++ b/Common/src/main/resources/data/botanypots/recipes/blueskies/soil/turquoise_farmland.json
@@ -16,5 +16,5 @@
       "dirt",
       "farmland"
     ],
-    "growthModifier": 1.10
+    "growthModifier": 1.00
   }

--- a/Common/src/main/resources/data/botanypots/recipes/createbb/crop/ephedra.json
+++ b/Common/src/main/resources/data/botanypots/recipes/createbb/crop/ephedra.json
@@ -1,0 +1,37 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "createbb:ephedra_seeds"
+      ]
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "createbb:ephedra_seeds"
+  },
+  "categories": [
+    "dirt",
+    "farmland"
+  ],
+  "growthTicks": 1200,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "createbb:ephedra_crop_block"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "createbb:ephedra"
+      }
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "createbb:ephedra_seeds"
+      }
+    }
+  ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/culturaldelights/crop/corn.json
+++ b/Common/src/main/resources/data/botanypots/recipes/culturaldelights/crop/corn.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "culturaldelights:corn_kernels"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "culturaldelights:corn_kernels"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "culturaldelights:corn_upper"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "culturaldelights:corn_cob"
+        }
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "culturaldelights:corn_kernels"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/culturaldelights/crop/cucumber.json
+++ b/Common/src/main/resources/data/botanypots/recipes/culturaldelights/crop/cucumber.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "culturaldelights:cucumber_seeds"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "culturaldelights:cucumber_seeds"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "culturaldelights:cucumbers"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "culturaldelights:cucumber"
+        }
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "culturaldelights:cucumber_seeds"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/culturaldelights/crop/eggplant.json
+++ b/Common/src/main/resources/data/botanypots/recipes/culturaldelights/crop/eggplant.json
@@ -1,0 +1,37 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "culturaldelights:eggplant_seeds"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "culturaldelights:eggplant_seeds"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1200,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "culturaldelights:eggplants"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "culturaldelights:eggplant"
+        }
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "culturaldelights:eggplant_seeds"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/aerlavender.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/aerlavender.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:aerlavender"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:aerlavender"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:aerlavender"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:aerlavender"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/aether_cattails.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/aether_cattails.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:aether_cattails"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:aether_cattails"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:aether_cattails"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:aether_cattails"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/echaisy.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/echaisy.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:echaisy"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:echaisy"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:echaisy"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:echaisy"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/enchanted_blossom.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/enchanted_blossom.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:enchanted_blossom"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:enchanted_blossom"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:enchanted_blossom"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:enchanted_blossom"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/golden_aspess.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/golden_aspess.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:golden_aspess"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:golden_aspess"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:golden_aspess"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:golden_aspess"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/golden_flower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/golden_flower.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:golden_flower"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:golden_flower"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:golden_flower"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:golden_flower"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/iaspove.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/iaspove.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:iaspove"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:iaspove"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:iaspove"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:iaspove"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/radiant_orchid.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/radiant_orchid.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:radiant_orchid"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:radiant_orchid"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:radiant_orchid"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:radiant_orchid"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/sky_tulips.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deep_aether/crop/sky_tulips.json
@@ -1,0 +1,33 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "deep_aether:sky_tulips"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "deep_aether:sky_tulips"
+    },
+    "categories": [
+      "dirt",
+      "grass",
+      "aether_grass",
+      "aether_dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "deep_aether:sky_tulips"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "deep_aether:sky_tulips"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deeperdarker/soil/echo_soil.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deeperdarker/soil/echo_soil.json
@@ -1,0 +1,14 @@
+{
+    "type": "botanypots:soil",
+    "input": {
+      "item": "deeperdarker:echo_soil"
+    },
+    "display": {
+      "block": "deeperdarker:echo_soil"
+    },
+    "categories": [
+      "dirt",
+      "sculk"
+    ],
+    "growthModifier": 1
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/deeperdarker/soil/echo_soil.json
+++ b/Common/src/main/resources/data/botanypots/recipes/deeperdarker/soil/echo_soil.json
@@ -1,4 +1,12 @@
 {
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "deeperdarker:echo_soil"
+      ]
+    }
+  ],
     "type": "botanypots:soil",
     "input": {
       "item": "deeperdarker:echo_soil"
@@ -8,6 +16,7 @@
     },
     "categories": [
       "dirt",
+      "farmland",
       "sculk"
     ],
     "growthModifier": 1

--- a/Common/src/main/resources/data/botanypots/recipes/delightful/crop/salmonberries.json
+++ b/Common/src/main/resources/data/botanypots/recipes/delightful/crop/salmonberries.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "delightful:salmonberries"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "delightful:salmonberries"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "delightful:salmonberry_bush"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "delightful:salmonberries"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/enlightend/crop/azure_berries.json
+++ b/Common/src/main/resources/data/botanypots/recipes/enlightend/crop/azure_berries.json
@@ -1,0 +1,32 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enlightened_end:azure_berries"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enlightened_end:azure_berries"
+    },
+    "categories": [
+      "chorloam",
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 2500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "enlightened_end:azure_berry_vine_1"
+    },
+    "drops": [
+        {
+            "chance": 1.00,
+            "output": {
+              "item": "enlightened_end:azure_berries"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/enlightend/crop/elevibloom.json
+++ b/Common/src/main/resources/data/botanypots/recipes/enlightend/crop/elevibloom.json
@@ -1,0 +1,39 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "enlightened_end:elevibloom_seeds",
+          "enlightened_end:elevibloom"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "enlightened_end:elevibloom_seeds"
+    },
+    "categories": [
+      "chorloam"
+    ],
+    "growthTicks": 2500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "enlightened_end:elevibloom_2"
+    },
+    "drops": [
+        {
+            "chance": 1.00,
+            "output": {
+              "item": "enlightened_end:elevibloom"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+          },
+          {
+            "chance": 0.001,
+            "output": {
+              "item": "enlightened_end:elevibloom"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/enlightend/soil/chorloam.json
+++ b/Common/src/main/resources/data/botanypots/recipes/enlightend/soil/chorloam.json
@@ -1,4 +1,12 @@
 {
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "enlightened_end:azure_berries"
+      ]
+    }
+  ],
     "type": "botanypots:soil",
     "input": {
       "item": "enlightened_end:chorloam"

--- a/Common/src/main/resources/data/botanypots/recipes/enlightend/soil/chorloam.json
+++ b/Common/src/main/resources/data/botanypots/recipes/enlightend/soil/chorloam.json
@@ -1,0 +1,13 @@
+{
+    "type": "botanypots:soil",
+    "input": {
+      "item": "enlightened_end:chorloam"
+    },
+    "display": {
+      "block": "enlightened_end:chorloam "
+    },
+    "categories": [
+      "chorloam"
+    ],
+    "growthModifier": 1
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/enlightend/soil/chorloam.json
+++ b/Common/src/main/resources/data/botanypots/recipes/enlightend/soil/chorloam.json
@@ -3,7 +3,7 @@
     {
       "type": "bookshelf:item_exists",
       "values": [
-        "enlightened_end:azure_berries"
+        "enlightened_end:chorloam"
       ]
     }
   ],

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/bird_of_paradise.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/bird_of_paradise.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:bird_of_paradise"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:bird_of_paradise"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:bird_of_paradise"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:bird_of_paradise"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/blue_delphinium.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/blue_delphinium.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:blue_delphinium"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:blue_delphinium"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:blue_delphinium"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:blue_delphinium"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/bluebell.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/bluebell.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:bluebell"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:bluebell"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:bluebell"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:bluebell"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/cartwheel.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/cartwheel.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:cartwheel"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:cartwheel"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:cartwheel"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:cartwheel"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/cattail_seeds.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/cattail_seeds.json
@@ -1,0 +1,39 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:cattail_seeds"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:cattail_seeds"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:cattail"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:cattail"
+        },
+        "minRolls": 1,
+        "maxRolls": 1
+      },
+      {
+        "chance": 0.1,
+        "output": {
+          "item": "environmental:cattail_seeds"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/dianthus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/dianthus.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:dianthus"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:dianthus"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:dianthus"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:dianthus"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/magenta_hibiscus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/magenta_hibiscus.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:magenta_hibiscus"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:magenta_hibiscus"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:magenta_hibiscus"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:magenta_hibiscus"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/orange_hibiscus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/orange_hibiscus.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:orange_hibiscus"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:orange_hibiscus"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:orange_hibiscus"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:orange_hibiscus"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/pink_delphinium.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/pink_delphinium.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:pink_delphinium"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:pink_delphinium"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:pink_delphinium"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:pink_delphinium"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/pink_hibiscus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/pink_hibiscus.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:pink_hibiscus"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:pink_hibiscus"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:pink_hibiscus"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:pink_hibiscus"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/purple_delphinium.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/purple_delphinium.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:purple_delphinium"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:purple_delphinium"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:purple_delphinium"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:purple_delphinium"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/purple_hibiscus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/purple_hibiscus.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:purple_hibiscus"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:purple_hibiscus"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:purple_hibiscus"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:purple_hibiscus"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/red_hibiscus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/red_hibiscus.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:red_hibiscus"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:red_hibiscus"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:red_hibiscus"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:red_hibiscus"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/red_lotus_flower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/red_lotus_flower.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:red_lotus_flower"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:red_lotus_flower"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:red_lotus_flower"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:red_lotus_flower"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/violet.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/violet.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:violet"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:violet"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:violet"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:violet"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/white_delphinium.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/white_delphinium.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:white_delphinium"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:white_delphinium"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:white_delphinium"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:white_delphinium"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/white_lotus_flower.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/white_lotus_flower.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:white_lotus_flower"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:white_lotus_flower"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:white_lotus_flower"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:white_lotus_flower"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/environmental/crop/yellow_hibiscus.json
+++ b/Common/src/main/resources/data/botanypots/recipes/environmental/crop/yellow_hibiscus.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "environmental:yellow_hibiscus"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "environmental:yellow_hibiscus"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "environmental:yellow_hibiscus"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "environmental:yellow_hibiscus"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/farmersrespite/crop/black_tea.json
+++ b/Common/src/main/resources/data/botanypots/recipes/farmersrespite/crop/black_tea.json
@@ -1,0 +1,47 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "farmersrespite:tea_seeds",
+          "farmersrespite:black_tea_leaves"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "farmersrespite:tea_seeds"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "farmersrespite:tea_bush"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "farmersrespite:black_tea_leaves"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+        },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+        },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "farmersrespite:tea_seeds"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/farmersrespite/crop/green_tea.json
+++ b/Common/src/main/resources/data/botanypots/recipes/farmersrespite/crop/green_tea.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "farmersrespite:green_tea_leaves"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "farmersrespite:green_tea_leaves"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "farmersrespite:tea_bush"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "farmersrespite:green_tea_leaves"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+        },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+        },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "farmersrespite:tea_seeds"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/farmersrespite/crop/yellow_tea.json
+++ b/Common/src/main/resources/data/botanypots/recipes/farmersrespite/crop/yellow_tea.json
@@ -1,0 +1,46 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "farmersrespite:yellow_tea_leaves"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "farmersrespite:yellow_tea_leaves"
+    },
+    "categories": [
+      "dirt"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "farmersrespite:tea_bush"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "farmersrespite:yellow_tea_leaves"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+        },
+      {
+        "chance": 0.25,
+        "output": {
+          "item": "minecraft:stick"
+        },
+        "minRolls": 1,
+        "maxRolls": 2
+        },
+      {
+        "chance": 0.05,
+        "output": {
+          "item": "farmersrespite:tea_seeds"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/forbidden_arcanus/crop/golden_orchid.json
+++ b/Common/src/main/resources/data/botanypots/recipes/forbidden_arcanus/crop/golden_orchid.json
@@ -1,0 +1,38 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "forbidden_arcanus:golden_orchid_seeds"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "forbidden_arcanus:golden_orchid_seeds"
+    },
+    "categories": [
+      "magical_farmland"
+    ],
+    "growthTicks": 2500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "forbidden_arcanus:golden_orchid"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:deorum_nugget"
+        },
+        "minRolls": 2,
+        "maxRolls": 4
+      },
+      {
+        "chance": 0.001,
+        "output": {
+          "item": "forbidden_arcanus:golden_orchid_seeds"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/forbidden_arcanus/crop/nipa_plant.json
+++ b/Common/src/main/resources/data/botanypots/recipes/forbidden_arcanus/crop/nipa_plant.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "forbidden_arcanus:nipa"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "forbidden_arcanus:nipa"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 3250,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "forbidden_arcanus:nipa"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:arcane_crystal_dust_speck"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/forbidden_arcanus/crop/yellow_orchid.json
+++ b/Common/src/main/resources/data/botanypots/recipes/forbidden_arcanus/crop/yellow_orchid.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "forbidden_arcanus:yellow_orchid"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "forbidden_arcanus:yellow_orchid"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "forbidden_arcanus:yellow_orchid"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "forbidden_arcanus:yellow_orchid"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/forbidden_arcanus/soil/magical_farmland.json
+++ b/Common/src/main/resources/data/botanypots/recipes/forbidden_arcanus/soil/magical_farmland.json
@@ -1,0 +1,21 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "forbidden_arcanus:magical_farmland"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "forbidden_arcanus:magical_farmland"
+    },
+    "display": {
+      "block": "forbidden_arcanus:magical_farmland"
+    },
+    "categories": [
+      "dirt",
+      "magical_farmland",
+      "farmland"
+    ],
+    "growthModifier": 1.00
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/mob_grinding_utils/soil/delightful_dirt.json
+++ b/Common/src/main/resources/data/botanypots/recipes/mob_grinding_utils/soil/delightful_dirt.json
@@ -2,19 +2,20 @@
     "bookshelf:load_conditions": [
       {
         "type": "bookshelf:item_exists",
-        "values": "blue_skies:lunar_farmland"
+        "values": "mob_grinding_utils:delightful_dirt"
       }
     ],
     "type": "botanypots:soil",
     "input": {
-      "item": "blue_skies:lunar_farmland"
+      "item": "mob_grinding_utils:delightful_dirt"
     },
     "display": {
-      "block": "blue_skies:lunar_farmland"
+      "block": "mob_grinding_utils:delightful_dirt"
     },
     "categories": [
       "dirt",
-      "farmland"
+      "farmland",
+      "grass"
     ],
-    "growthModifier": 1.00
+    "growthModifier": 1.10
   }

--- a/Common/src/main/resources/data/botanypots/recipes/mysticalagriculture/crop/flux_infused_gem.json
+++ b/Common/src/main/resources/data/botanypots/recipes/mysticalagriculture/crop/flux_infused_gem.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "mysticalagriculture:flux_infused_gem_seeds",
+          "mysticalagriculture:flux_infused_gem_essence"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "mysticalagriculture:flux_infused_gem_seeds"
+    },
+    "categories": [
+      "supremium"
+    ],
+    "growthTicks": 3600,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "mysticalagriculture:flux_infused_gem_crop"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "mysticalagriculture:flux_infused_gem_essence"
+        }
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "mysticalagriculture:flux_infused_gem_seeds"
+        }
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "mysticalagriculture:fertilized_essence"
+        },
+        "minRolls": 1,
+        "maxRolls": 1
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/mysticalagriculture/crop/flux_infused_ingot.json
+++ b/Common/src/main/resources/data/botanypots/recipes/mysticalagriculture/crop/flux_infused_ingot.json
@@ -1,0 +1,45 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "mysticalagriculture:flux_infused_ingot_seeds",
+          "mysticalagriculture:flux_infused_ingot_essence"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "mysticalagriculture:flux_infused_ingot_seeds"
+    },
+    "categories": [
+      "imperium"
+    ],
+    "growthTicks": 3600,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "mysticalagriculture:flux_infused_ingot_crop"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "mysticalagriculture:flux_infused_ingot_essence"
+        }
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "mysticalagriculture:flux_infused_ingot_seeds"
+        }
+      },
+      {
+        "chance": 0.01,
+        "output": {
+          "item": "mysticalagriculture:fertilized_essence"
+        },
+        "minRolls": 1,
+        "maxRolls": 1
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/adzuki_beans.json
+++ b/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/adzuki_beans.json
@@ -1,0 +1,31 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "neapolitan:adzuki_beans"
+      ]
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "neapolitan:adzuki_beans"
+  },
+  "categories": [
+    "dirt",
+    "farmland"
+  ],
+  "growthTicks": 1500,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "neapolitan:adzuki_sprouts"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "neapolitan:adzuki_beans"
+      }
+    }
+  ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/banana_plant.json
+++ b/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/banana_plant.json
@@ -1,0 +1,48 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "neapolitan:banana_frond"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "neapolitan:banana_frond"
+    },
+    "categories": [
+      "dirt",
+      "sand",
+      "gravel"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "neapolitan:banana_frond"
+    },
+    "drops": [
+        {
+            "chance": 1.00,
+            "output": {
+              "item": "neapolitan:banana"
+            },
+            "minRolls": 2,
+            "maxRolls": 4
+            },
+          {
+            "chance": 0.25,
+            "output": {
+              "item": "neapolitan:banana_stalk"
+            },
+            "minRolls": 1,
+            "maxRolls": 2
+            },
+          {
+            "chance": 0.25,
+            "output": {
+              "item": "neapolitan:banana_frond"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/mint.json
+++ b/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/mint.json
@@ -1,0 +1,31 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "neapolitan:mint_sprout"
+      ]
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "neapolitan:mint_sprout"
+  },
+  "categories": [
+    "dirt",
+    "farmland"
+  ],
+  "growthTicks": 1500,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "neapolitan:mint"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "neapolitan:mint_leaves"
+      }
+    }
+  ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/strawberries.json
+++ b/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/strawberries.json
@@ -1,0 +1,31 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "neapolitan:strawberries"
+      ]
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "neapolitan:strawberries"
+  },
+  "categories": [
+    "dirt",
+    "farmland"
+  ],
+  "growthTicks": 1500,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "neapolitan:strawberry_bush"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "neapolitan:strawberries"
+      }
+    }
+  ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/vanilla_pods.json
+++ b/Common/src/main/resources/data/botanypots/recipes/neapolitan/crop/vanilla_pods.json
@@ -1,0 +1,31 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "neapolitan:vanilla_pods"
+      ]
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "neapolitan:vanilla_pods"
+  },
+  "categories": [
+    "dirt",
+    "farmland"
+  ],
+  "growthTicks": 1500,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "neapolitan:vanilla_vine"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "neapolitan:vanilla_pods"
+      }
+    }
+  ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/pyromancer/crop/blazing_poppy.json
+++ b/Common/src/main/resources/data/botanypots/recipes/pyromancer/crop/blazing_poppy.json
@@ -1,0 +1,30 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pyromancer:blazing_poppy"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pyromancer:blazing_poppy"
+    },
+    "categories": [
+      "pyromossed_netherrack"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "pyromancer:blazing_poppy"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "pyromancer:blazing_poppy"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/pyromancer/crop/nether_lily.json
+++ b/Common/src/main/resources/data/botanypots/recipes/pyromancer/crop/nether_lily.json
@@ -1,0 +1,30 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "pyromancer:nether_lily"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "pyromancer:nether_lily"
+    },
+    "categories": [
+      "pyromossed_netherrack"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "pyromancer:nether_lily"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "pyromancer:nether_lily"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/pyromancer/soil/pyromossed_netherrack.json
+++ b/Common/src/main/resources/data/botanypots/recipes/pyromancer/soil/pyromossed_netherrack.json
@@ -1,0 +1,22 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "pyromancer:pyromossed_netherrack"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "pyromancer:pyromossed_netherrack"
+    },
+    "display": {
+      "block": "pyromancer:pyromossed_netherrack"
+    },
+    "categories": [
+      "nylium",
+      "pyromossed_netherrack",
+      "netherrack",
+      "nether"
+    ],
+    "growthModifier": 1
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/regions_unexplored/soil/brimsprout_nylium.json
+++ b/Common/src/main/resources/data/botanypots/recipes/regions_unexplored/soil/brimsprout_nylium.json
@@ -1,0 +1,23 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "regions_unexplored:brimsprout_nylium"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "regions_unexplored:brimsprout_nylium"
+    },
+    "display": {
+      "block": "regions_unexplored:brimsprout_nylium"
+    },
+    "categories": [
+      "mushroom",
+      "nylium",
+      "brimsprout_nylium",
+      "netherrack",
+      "nether"
+    ],
+    "growthModifier": 1
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/undergarden/crop/gloomgourd.json
+++ b/Common/src/main/resources/data/botanypots/recipes/undergarden/crop/gloomgourd.json
@@ -1,0 +1,37 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "undergarden:gloomgourd_seeds"
+      ]
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "undergarden:gloomgourd_seeds"
+  },
+  "categories": [
+    "dirt",
+    "farmland"
+  ],
+  "growthTicks": 1200,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "undergarden:gloomgourd"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "undergarden:gloomgourd"
+      }
+    },
+    {
+      "chance": 0.01,
+      "output": {
+        "item": "undergarden:gloomgourd_seeds"
+      }
+    }
+  ]
+}

--- a/Common/src/main/resources/data/botanypots/recipes/undergarden/soil/deepsoil.json
+++ b/Common/src/main/resources/data/botanypots/recipes/undergarden/soil/deepsoil.json
@@ -1,0 +1,22 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "undergarden:deepsoil_farmland"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "undergarden:deepsoil_farmland"
+    },
+    "display": {
+      "block": "undergarden:deepsoil_farmland"
+    },
+    "categories": [
+      "dirt",
+      "deepsoil",
+      "deepsoil_farmland",
+      "farmland"
+    ],
+    "growthModifier": 1.00
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/undergarden/soil/deepsoil_farmland.json
+++ b/Common/src/main/resources/data/botanypots/recipes/undergarden/soil/deepsoil_farmland.json
@@ -1,0 +1,20 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": "undergarden:deepsoil"
+      }
+    ],
+    "type": "botanypots:soil",
+    "input": {
+      "item": "undergarden:deepsoil"
+    },
+    "display": {
+      "block": "undergarden:deepsoil"
+    },
+    "categories": [
+      "dirt",
+      "deepsoil"
+    ],
+    "growthModifier": 1.00
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/blue_rose.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/blue_rose.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:blue_rose"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:blue_rose"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:blue_rose"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:blue_rose"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/bluebells.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/bluebells.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:bluebells"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:bluebells"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:bluebells"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:bluebells"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/foxglove.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/foxglove.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:foxglove"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:foxglove"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:foxglove"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:foxglove"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/nightshade.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/nightshade.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:nightshade"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:nightshade"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:nightshade"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:nightshade"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/pink_rose.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/pink_rose.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:pink_rose"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:pink_rose"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:pink_rose"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:pink_rose"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/red_rose.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/red_rose.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:red_rose"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:red_rose"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:red_rose"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:red_rose"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/white_rose.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/white_rose.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:white_rose"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:white_rose"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:white_rose"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:white_rose"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/wild_berries.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/wild_berries.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:wild_berries"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:wild_berries"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 2750,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:wild_berry_bush"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:wild_berries"
+        }
+      }
+    ]
+  }

--- a/Common/src/main/resources/data/botanypots/recipes/windswept/crop/yellow_rose.json
+++ b/Common/src/main/resources/data/botanypots/recipes/windswept/crop/yellow_rose.json
@@ -1,0 +1,31 @@
+{
+    "bookshelf:load_conditions": [
+      {
+        "type": "bookshelf:item_exists",
+        "values": [
+          "windswept:yellow_rose"
+        ]
+      }
+    ],
+    "type": "botanypots:crop",
+    "seed": {
+      "item": "windswept:yellow_rose"
+    },
+    "categories": [
+      "dirt",
+      "farmland"
+    ],
+    "growthTicks": 1500,
+    "display": {
+      "type": "botanypots:aging",
+      "block": "windswept:yellow_rose"
+    },
+    "drops": [
+      {
+        "chance": 1.00,
+        "output": {
+          "item": "windswept:yellow_rose"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
The format is consistent from 1.19.2 and up, so it should work on versions like 1.20.1.

If you are to accept this pull request, the following will be added to support Botany Pots:

Added support for Create: Broken Bad's Ephedra
Added support for Cultural Delight crops
Added support for Deeper & Darker's Echo Soil
Added support for Delightful's Salmonberry
Added support for Enlightend
Added support for Environmental
Added support for Farmer's Respite
Added support for Forbidden & arcanus
Added support for Neapolitan
Added support for Windswept
Added support for The Aether
Added support for the Undergarden soils and Gloomgourd
Added support for a missing Regions Unexplored soil, Brimsprout Nylium
Added support for Pyromossed Netherrack from Pyromancer
Added support for The Aether Redux
Added support for Deep Aether

Feel free to make any necessary edits. 