### PR TITLE
Redstone disabled pots

### DIFF
--- a/common/src/main/java/net/darkhax/botanypots/block/BlockEntityBotanyPot.java
+++ b/common/src/main/java/net/darkhax/botanypots/block/BlockEntityBotanyPot.java
@@ -223,6 +223,12 @@ public class BlockEntityBotanyPot extends WorldlyInventoryBlockEntity<BotanyPotC
             return;
         }
 
+        // Disable pot operations when given a redstone signal.
+        if (pot.getLevel().hasNeighborSignal(pos)) {
+
+            return;
+        }
+
         pot.getInventory().update();
 
         final Soil soil = pot.getSoil();


### PR DESCRIPTION
Added a check that cancels hopper and growth operations when a botany pot has a redstone signal.

Proposed solution for #341 and #208 currently implemented for [1.20.4]