### PR TITLE
[1.20.1] [Collector's Reap] Compatability

### DIFF
--- a/common/src/main/resources/data/botanypots/recipes/collectorsreap/lime.json
+++ b/common/src/main/resources/data/botanypots/recipes/collectorsreap/lime.json
@@ -1,0 +1,65 @@
+{
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "collectorsreap:lime_seeds"
+  },
+  "categories": [
+    "dirt",
+    "farmland"
+  ],
+  "growthTicks": 1800,
+  "display": {
+    "type": "botanypots:transitional",
+    "phases": [
+      {
+        "block": "collectorsreap:lime_bush",
+        "properties": {
+          "age": 0,
+          "half": "lower"
+        }
+      },
+      {
+        "block": "collectorsreap:lime_bush",
+        "properties": {
+          "age": 1,
+          "half": "lower"
+        }
+      },
+      {
+        "block": "collectorsreap:lime_bush",
+        "properties": {
+          "age": 2,
+          "half": "upper"
+        }
+      },
+      {
+        "block": "collectorsreap:lime_bush",
+        "properties": {
+          "age": 3,
+          "half": "upper"
+        }
+      },
+      {
+        "block": "collectorsreap:lime_bush",
+        "properties": {
+          "age": 4,
+          "half": "upper"
+        }
+      }
+    ]
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "collectorsreap:lime"
+      }
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "collectorsreap:lime_seeds"
+      }
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipes/collectorsreap/pomegranate.json
+++ b/common/src/main/resources/data/botanypots/recipes/collectorsreap/pomegranate.json
@@ -1,0 +1,65 @@
+{
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "collectorsreap:pomegranate_seeds"
+  },
+  "categories": [
+    "nylium",
+    "rich_soul"
+  ],
+  "growthTicks": 1800,
+  "display": {
+    "type": "botanypots:transitional",
+    "phases": [
+      {
+        "block": "collectorsreap:pomegranate_bush",
+        "properties": {
+          "age": 0,
+          "half": "lower"
+        }
+      },
+      {
+        "block": "collectorsreap:pomegranate_bush",
+        "properties": {
+          "age": 1,
+          "half": "lower"
+        }
+      },
+      {
+        "block": "collectorsreap:pomegranate_bush",
+        "properties": {
+          "age": 2,
+          "half": "upper"
+        }
+      },
+      {
+        "block": "collectorsreap:pomegranate_bush",
+        "properties": {
+          "age": 3,
+          "half": "upper"
+        }
+      },
+      {
+        "block": "collectorsreap:pomegranate_bush",
+        "properties": {
+          "age": 4,
+          "half": "upper"
+        }
+      }
+    ]
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "collectorsreap:pomegranate"
+      }
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "collectorsreap:pomegranate_seeds"
+      }
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipes/collectorsreap/portobello.json
+++ b/common/src/main/resources/data/botanypots/recipes/collectorsreap/portobello.json
@@ -1,0 +1,23 @@
+{
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "collectorsreap:portobello"
+  },
+  "categories": [
+    "stone",
+    "mushroom",
+    "mulch"
+  ],
+  "growthTicks": 1200,
+  "display": {
+    "block": "collectorsreap:portobello"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "collectorsreap:portobello"
+      }
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipes/collectorsreap/portobello_mushroom_colony.json
+++ b/common/src/main/resources/data/botanypots/recipes/collectorsreap/portobello_mushroom_colony.json
@@ -1,0 +1,40 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:item_exists",
+      "values": [
+        "collectorsreap:portobello_colony"
+      ]
+    }
+  ],
+  "type": "botanypots:crop",
+  "seed": {
+    "item": "collectorsreap:portobello_colony"
+  },
+  "categories": [
+    "mushroom"
+  ],
+  "growthTicks": 1400,
+  "display": {
+    "type": "botanypots:aging",
+    "block": "collectorsreap:portobello_colony"
+  },
+  "drops": [
+    {
+      "chance": 1.00,
+      "output": {
+        "item": "collectorsreap:portobello"
+      },
+      "minRolls": 1,
+      "maxRolls": 3
+    },
+    {
+      "chance": 0.05,
+      "output": {
+        "item": "collectorsreap:portobello"
+      },
+      "minRolls": 1,
+      "maxRolls": 2
+    }
+  ]
+}


### PR DESCRIPTION
Added compatibility for [Collector's Reap] as wanted for #424

Notes:
there is a balance related issues as limes can only be fully grown in world when pollenated by a bee
Pomegranates can be only be grown in botany pots using nylium/rich soul soil since growth outside the nether requires bee pollination and there is no way to see if the pot itself is in the nether or not
Pomegranates in world can still grow in the nether on other soils though

Tested using:
Collector's Reap 1.3.2
Farmer's Delight 1.2.4
Nether's Delight  4.0 (for rich soul soil)
