### PR TITLE
Recipe fix for Hexerei's Bellodana and mandrake herbs in mod versions 4.0+

### DIFF
--- a/common/src/main/resources/data/botanypots/recipes/hexerei/crop/belladonna.json
+++ b/common/src/main/resources/data/botanypots/recipes/hexerei/crop/belladonna.json
@@ -5,13 +5,13 @@
       "values": [
         "hexerei:belladonna_berries",
         "hexerei:belladonna_flowers",
-        "hexerei:belladonna_flower"
+        "hexerei:belladonna_plant"
       ]
     }
   ],
   "type": "botanypots:crop",
   "seed": {
-    "item": "hexerei:belladonna_flower"
+    "item": "hexerei:belladonna_plant"
   },
   "categories": [
     "dirt"
@@ -37,7 +37,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "hexerei:belladonna_flower"
+        "item": "hexerei:belladonna_plant"
       }
     }
   ]

--- a/common/src/main/resources/data/botanypots/recipes/hexerei/crop/mandrake.json
+++ b/common/src/main/resources/data/botanypots/recipes/hexerei/crop/mandrake.json
@@ -5,13 +5,13 @@
       "values": [
         "hexerei:mandrake_flowers",
         "hexerei:mandrake_root",
-        "hexerei:mandrake_flower"
+        "hexerei:mandrake_plant"
       ]
     }
   ],
   "type": "botanypots:crop",
   "seed": {
-    "item": "hexerei:mandrake_flower"
+    "item": "hexerei:mandrake_plant"
   },
   "categories": [
     "dirt"
@@ -37,7 +37,7 @@
     {
       "chance": 0.05,
       "output": {
-        "item": "hexerei:mandrake_flower"
+        "item": "hexerei:mandrake_plant"
       }
     }
   ]


### PR DESCRIPTION
The tags in newer versions (4.0+) of hexerei changed causing hexerei:bellodana_flower and hexerei:mandrake_flower to be replaced with _plant