### PR TITLE
Update Delightful's Cantaloupe to grow in Sand instead of Dirt

### DIFF
--- a/common/src/main/resources/data/botanypots/recipes/delightful/crop/cantaloupe.json
+++ b/common/src/main/resources/data/botanypots/recipes/delightful/crop/cantaloupe.json
@@ -12,7 +12,7 @@
     "item": "delightful:cantaloupe_seeds"
   },
   "categories": [
-    "dirt"
+    "sand"
   ],
   "growthTicks": 1800,
   "display": {


### PR DESCRIPTION
Cantaloupes from Delightful (my mod) are only plantable in Sand. However, this compat was submitted with them in the dirt category. This fixes their soil to be Sand.