### PR TITLE
Fulfil #464 - Added RMB fill feature

### DIFF
--- a/common/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
+++ b/common/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
@@ -164,6 +164,23 @@ public class BlockBotanyPot extends InventoryBlock implements SimpleWaterloggedB
                 return InteractionResult.CONSUME;
             }
 
+            // Attempt to fill the pot with soil or seed
+            else if (!player.isCrouching() && (potEntity.isValidSeed(heldStack) || potEntity.isValidSoil(heldStack))) {
+
+                if (potEntity.isValidSeed(heldStack) && potEntity.getCrop() == null) {
+
+                    potEntity.getInventory().setItem(1, new ItemStack(heldStack.getItem(), 1));
+
+                    player.getItemInHand(hand).setCount(heldStack.getCount() - 1);
+
+                } else if (potEntity.isValidSoil(heldStack) && potEntity.getSoil() == null) {
+
+                    potEntity.getInventory().setItem(0, new ItemStack(heldStack.getItem(), 1));
+
+                    player.getItemInHand(hand).setCount(heldStack.getCount() - 1);
+                }
+            }
+
             // Open the pot GUI
             else if (player instanceof ServerPlayer serverPlayer) {
 


### PR DESCRIPTION
This feature #464  which lets the player fill a pot from in the world as opposed to interaction with the inventory.  This saves the player many mouse clicks and movements - especially those who choose to create large farms.  

If desired, I can port this over to other versions as well as it's a fairly small and simple addition.  My friend and I are currently using this mod on our modded server and have yet to encounter issues with it.