### PR TITLE
[1.21.1] Add Botany Pots interaction: till rich soil into rich soil farmland

### DIFF
--- a/common/src/main/resources/data/botanypots/recipe/farmersdelight/interaction/till_rich_soil_farmland.json
+++ b/common/src/main/resources/data/botanypots/recipe/farmersdelight/interaction/till_rich_soil_farmland.json
@@ -1,0 +1,24 @@
+{
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "farmersdelight:rich_soil"
+      ]
+    }
+  ],
+  "type": "botanypots:pot_interaction",
+  "held_item": {
+    "tag": "minecraft:hoes"
+  },
+  "soil_item": {
+    "item": "farmersdelight:rich_soil"
+  },
+  "new_soil": {
+    "id": "farmersdelight:rich_soil_farmland"
+  },
+  "sound_effect": {
+    "id": "minecraft:item.hoe.till",
+    "category": "BLOCKS"
+  }
+}


### PR DESCRIPTION
Adds a Botany Pots interaction for Farmers Delight Rich Soil:

- Allows hoes to till `farmersdelight:rich_soil` into `farmersdelight:rich_soil_farmland` when placed in a Botany Pot.

Tested locally:
- Works as expected with Farmers Delight installed.
- No errors when Farmers Delight is absent.
