### PR TITLE
fix: add @OnlyIn(Dist.CLIENT) to client-only method in BotanyPotBlock

### DIFF
--- a/common/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
+++ b/common/src/main/java/net/darkhax/botanypots/block/BlockBotanyPot.java
@@ -33,6 +33,8 @@ import net.minecraft.world.level.material.MapColor;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 
 public class BlockBotanyPot extends InventoryBlock implements SimpleWaterloggedBlock, IBindRenderLayer {
 
@@ -184,6 +186,7 @@ public class BlockBotanyPot extends InventoryBlock implements SimpleWaterloggedB
     }
 
     @Override
+    @OnlyIn(Dist.CLIENT)
     public RenderType getRenderLayerToBind() {
 
         return RenderType.cutout();


### PR DESCRIPTION
Prevents a Radium/Lithium Class Analysis error on dedicated servers. The method `getRenderLayerToBind` references `RenderType`, which is not available in the server distribution.

Resolves Radium RuntimeException: Attempted to load class RenderType for invalid dist DEDICATED_SERVER. 