### PR TITLE
Fix: Add Biomes O'Plenty compatibility for 1.21.1

### DIFF
--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/barley.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/barley.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:barley",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:barley"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/blackstone_bulb.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/blackstone_bulb.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:blackstone_bulb",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:blackstone_bulb"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/blue_hydrangea.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/blue_hydrangea.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:blue_hydrangea",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:blue_hydrangea"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/bramble.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/bramble.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:bramble",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:bramble"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/burning_blossom.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/burning_blossom.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:burning_blossom",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:burning_blossom"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/cattail.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/cattail.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:cattail",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:cattail"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/clover.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/clover.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:clover",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:clover"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/flesh_tendons.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/flesh_tendons.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:flesh_tendons",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:flesh_tendons"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/glowflower.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/glowflower.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:glowflower",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:glowflower"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/glowshroom.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/glowshroom.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:glowshroom",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:glowshroom"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/goldenrod.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/goldenrod.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:goldenrod",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:goldenrod"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/hair.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/hair.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:hair",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:hair"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/huge_clover_petal.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/huge_clover_petal.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:huge_clover_petal",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:huge_clover_petal"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/lavender.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/lavender.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:lavender",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:lavender"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/orange_cosmos.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/orange_cosmos.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:orange_cosmos",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:orange_cosmos"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/pink_daffodil.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/pink_daffodil.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:pink_daffodil",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:pink_daffodil"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/pink_hibiscus.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/pink_hibiscus.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:pink_hibiscus",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:pink_hibiscus"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/rose.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/rose.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:rose",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:rose"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/sea_oats.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/sea_oats.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:sea_oats",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:sea_oats"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/spanish_moss.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/spanish_moss.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:spanish_moss",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:spanish_moss"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/toadstool.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/toadstool.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:toadstool",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:toadstool"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/violet.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/violet.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:violet",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:violet"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/wildflower.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/wildflower.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:wildflower",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:wildflower"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/willow_vine.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/willow_vine.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:willow_vine",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:willow_vine"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/wilted_lily.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/crop/wilted_lily.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_crop",
+  "block": "biomesoplenty:wilted_lily",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:wilted_lily"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/black_sand.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/black_sand.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_soil",
+  "block": "biomesoplenty:black_sand",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:black_sand"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/flesh.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/flesh.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_soil",
+  "block": "biomesoplenty:flesh",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:flesh"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/mud.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/mud.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_soil",
+  "block": "biomesoplenty:mud",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:mud"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/orange_sand.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/orange_sand.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_soil",
+  "block": "biomesoplenty:orange_sand",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:orange_sand"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/origin_grass_block.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/origin_grass_block.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_soil",
+  "block": "biomesoplenty:origin_grass_block",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:origin_grass_block"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/porous_flesh.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/porous_flesh.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_soil",
+  "block": "biomesoplenty:porous_flesh",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:porous_flesh"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/rooted_sand.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/rooted_sand.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_soil",
+  "block": "biomesoplenty:rooted_sand",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:rooted_sand"
+      ]
+    }
+  ]
+}

--- a/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/white_sand.json
+++ b/common/src/main/resources/data/botanypots/recipe/biomesoplenty/soil/white_sand.json
@@ -1,0 +1,12 @@
+{
+  "type": "botanypots:block_derived_soil",
+  "block": "biomesoplenty:white_sand",
+  "bookshelf:load_conditions": [
+    {
+      "type": "bookshelf:block_exists",
+      "values": [
+        "biomesoplenty:white_sand"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
This PR adds Biomes O'Plenty compatibility for Minecraft 1.21.1, restoring the crop and soil recipes that were present in 1.20.1 but missing in the 1.21.1 version.

## Changes
- Added 25 crop recipes for Biomes O'Plenty plants (barley, lavender, rose, etc.)
- Added 8 soil recipes for Biomes O'Plenty soil types (mud, black_sand, white_sand, etc.)
- Uses the new 1.21.1 format with block_derived_crop and block_derived_soil types
- Includes bookshelf load conditions for conditional loading when Biomes O'Plenty is installed

## Related Issue
Fixes #500